### PR TITLE
feat: add support for HF Token Secret

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,12 +44,9 @@
     "!projenrc/**/*.ts"
   ],
   "rules": {
-    "curly": [
-      "error",
-      "multi-line",
-      "consistent"
+    "@typescript-eslint/no-require-imports": [
+      "error"
     ],
-    "@typescript-eslint/no-require-imports": "error",
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -73,12 +70,27 @@
     "no-shadow": [
       "off"
     ],
-    "@typescript-eslint/no-shadow": "error",
-    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-shadow": [
+      "error"
+    ],
+    "key-spacing": [
+      "error"
+    ],
+    "no-multiple-empty-lines": [
+      "error"
+    ],
+    "@typescript-eslint/no-floating-promises": [
+      "error"
+    ],
     "no-return-await": [
       "off"
     ],
-    "@typescript-eslint/return-await": "error",
+    "@typescript-eslint/return-await": [
+      "error"
+    ],
+    "no-trailing-spaces": [
+      "error"
+    ],
     "dot-notation": [
       "error"
     ],

--- a/API.md
+++ b/API.md
@@ -5557,6 +5557,7 @@ const neuronxCompilerProps: NeuronxCompilerProps = { ... }
 | <code><a href="#aws-cdk-neuronx-patterns.NeuronxCompilerProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | VPC in which this will launch compile worker instance. |
 | <code><a href="#aws-cdk-neuronx-patterns.NeuronxCompilerProps.property.command">command</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#aws-cdk-neuronx-patterns.NeuronxCompilerProps.property.environment">environment</a></code> | <code>{[ key: string ]: string}</code> | The environment variables to pass to the container. |
+| <code><a href="#aws-cdk-neuronx-patterns.NeuronxCompilerProps.property.secrets">secrets</a></code> | <code>{[ key: string ]: aws-cdk-lib.aws_batch.Secret}</code> | Secrets to pass to the container. |
 | <code><a href="#aws-cdk-neuronx-patterns.NeuronxCompilerProps.property.spot">spot</a></code> | <code>boolean</code> | Whether or not to use spot instances. |
 | <code><a href="#aws-cdk-neuronx-patterns.NeuronxCompilerProps.property.volumeSize">volumeSize</a></code> | <code>aws-cdk-lib.Size</code> | The root volume of worker instance. |
 | <code><a href="#aws-cdk-neuronx-patterns.NeuronxCompilerProps.property.vpcSubnets">vpcSubnets</a></code> | <code>aws-cdk-lib.aws_ec2.SubnetSelection</code> | The VPC Subnets this Compute Environment will launch instances in. |
@@ -5659,6 +5660,18 @@ public readonly environment: {[ key: string ]: string};
 The environment variables to pass to the container.
 
 This is only applicable when using container runtime.
+
+---
+
+##### `secrets`<sup>Optional</sup> <a name="secrets" id="aws-cdk-neuronx-patterns.NeuronxCompilerProps.property.secrets"></a>
+
+```typescript
+public readonly secrets: {[ key: string ]: Secret};
+```
+
+- *Type:* {[ key: string ]: aws-cdk-lib.aws_batch.Secret}
+
+Secrets to pass to the container.
 
 ---
 
@@ -6455,7 +6468,7 @@ const vllmEngineArguments: VllmEngineArguments = { ... }
 | <code><a href="#aws-cdk-neuronx-patterns.VllmEngineArguments.property.generationConfig">generationConfig</a></code> | <code>string</code> | The folder path to the generation config. |
 | <code><a href="#aws-cdk-neuronx-patterns.VllmEngineArguments.property.hfConfigPath">hfConfigPath</a></code> | <code>string</code> | Name or path of the huggingface config to use. |
 | <code><a href="#aws-cdk-neuronx-patterns.VllmEngineArguments.property.hfOverrides">hfOverrides</a></code> | <code>{[ key: string ]: any}</code> | Extra arguments for the HuggingFace config. |
-| <code><a href="#aws-cdk-neuronx-patterns.VllmEngineArguments.property.hfToken">hfToken</a></code> | <code>boolean</code> | The token to use as HTTP bearer authorization for remote files. |
+| <code><a href="#aws-cdk-neuronx-patterns.VllmEngineArguments.property.hfToken">hfToken</a></code> | <code>aws-cdk-lib.aws_batch.Secret</code> | The token to use as HTTP bearer authorization for remote files. |
 | <code><a href="#aws-cdk-neuronx-patterns.VllmEngineArguments.property.host">host</a></code> | <code>string</code> | Host name. |
 | <code><a href="#aws-cdk-neuronx-patterns.VllmEngineArguments.property.ignorePatterns">ignorePatterns</a></code> | <code>string[]</code> | The pattern(s) to ignore when loading the model.Default to original/**\/* to avoid repeated loading of llama’s checkpoints. |
 | <code><a href="#aws-cdk-neuronx-patterns.VllmEngineArguments.property.kvTransferConfig">kvTransferConfig</a></code> | <code>{[ key: string ]: any}</code> | Configurations for distributed KV cache transfer in object. |
@@ -7039,14 +7052,14 @@ This should be a object that will be parsed into a dictionary.
 ##### `hfToken`<sup>Optional</sup> <a name="hfToken" id="aws-cdk-neuronx-patterns.VllmEngineArguments.property.hfToken"></a>
 
 ```typescript
-public readonly hfToken: boolean;
+public readonly hfToken: Secret;
 ```
 
-- *Type:* boolean
+- *Type:* aws-cdk-lib.aws_batch.Secret
 
 The token to use as HTTP bearer authorization for remote files.
 
-If True, will use the token generated when running huggingface-cli login (stored in ~/.huggingface)..
+If provided, the Secret will be passed as HF_TOKEN secret to compile environment.
 
 ---
 
@@ -8794,7 +8807,7 @@ const vllmNamedArguments: VllmNamedArguments = { ... }
 | <code><a href="#aws-cdk-neuronx-patterns.VllmNamedArguments.property.generationConfig">generationConfig</a></code> | <code>string</code> | The folder path to the generation config. |
 | <code><a href="#aws-cdk-neuronx-patterns.VllmNamedArguments.property.hfConfigPath">hfConfigPath</a></code> | <code>string</code> | Name or path of the huggingface config to use. |
 | <code><a href="#aws-cdk-neuronx-patterns.VllmNamedArguments.property.hfOverrides">hfOverrides</a></code> | <code>{[ key: string ]: any}</code> | Extra arguments for the HuggingFace config. |
-| <code><a href="#aws-cdk-neuronx-patterns.VllmNamedArguments.property.hfToken">hfToken</a></code> | <code>boolean</code> | The token to use as HTTP bearer authorization for remote files. |
+| <code><a href="#aws-cdk-neuronx-patterns.VllmNamedArguments.property.hfToken">hfToken</a></code> | <code>aws-cdk-lib.aws_batch.Secret</code> | The token to use as HTTP bearer authorization for remote files. |
 | <code><a href="#aws-cdk-neuronx-patterns.VllmNamedArguments.property.host">host</a></code> | <code>string</code> | Host name. |
 | <code><a href="#aws-cdk-neuronx-patterns.VllmNamedArguments.property.ignorePatterns">ignorePatterns</a></code> | <code>string[]</code> | The pattern(s) to ignore when loading the model.Default to original/**\/* to avoid repeated loading of llama’s checkpoints. |
 | <code><a href="#aws-cdk-neuronx-patterns.VllmNamedArguments.property.kvTransferConfig">kvTransferConfig</a></code> | <code>{[ key: string ]: any}</code> | Configurations for distributed KV cache transfer in object. |
@@ -9327,14 +9340,14 @@ This should be a object that will be parsed into a dictionary.
 ##### `hfToken`<sup>Optional</sup> <a name="hfToken" id="aws-cdk-neuronx-patterns.VllmNamedArguments.property.hfToken"></a>
 
 ```typescript
-public readonly hfToken: boolean;
+public readonly hfToken: Secret;
 ```
 
-- *Type:* boolean
+- *Type:* aws-cdk-lib.aws_batch.Secret
 
 The token to use as HTTP bearer authorization for remote files.
 
-If True, will use the token generated when running huggingface-cli login (stored in ~/.huggingface)..
+If provided, the Secret will be passed as HF_TOKEN secret to compile environment.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,52 @@ The construct will automatically:
 
 The service exposes a REST API endpoint through the Application Load Balancer that can be used to perform inference with the deployed model.
 
+### Using HuggingFace Token with Secrets Manager
+
+When working with private or gated models on HuggingFace, you need to provide an authentication token. For security best practices, you can store your HuggingFace token in AWS Secrets Manager and pass it to both the compiler and inference environments:
+
+```ts
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+
+declare const vpc: ec2.Vpc;
+declare const bucket: s3.Bucket;
+
+// Create or reference an existing secret containing your HuggingFace token
+const hfTokenSecret = Secret.fromSecretNameV2(this, "HFTokenSecret", "my-huggingface-token");
+
+// Pass the secret to the compiler
+const compiler = new VllmNxdInferenceCompiler(this, "Compiler", {
+  vpc,
+  bucket,
+  model: Model.fromHuggingFace("example/example-7b-chat"),
+  vllmArgs: {
+    hfToken: hfTokenSecret, // Pass the HF token secret here
+  },
+});
+
+const compiledModel = compiler.compile();
+const taskDefinition = new VllmNxdInferenceTaskDefinition(
+  this,
+  "TaskDefinition",
+  {
+    compiledModel,
+  },
+);
+
+const service = new ApplicationLoadBalancedVllmNxDInferenceService(
+  this,
+  "Service",
+  {
+    vpc,
+    taskDefinition,
+  },
+);
+```
+
+The secret will be securely passed as an environment variable to the compilation batch job and the ECS tasks running the inference server.
+
 ## Neuronx Compiler
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -57,20 +57,26 @@ The construct will automatically:
 
 The service exposes a REST API endpoint through the Application Load Balancer that can be used to perform inference with the deployed model.
 
-### Using HuggingFace Token with Secrets Manager
+### Using HuggingFace Token with Secrets
 
-When working with private or gated models on HuggingFace, you need to provide an authentication token. For security best practices, you can store your HuggingFace token in AWS Secrets Manager and pass it to both the compiler and inference environments:
+When working with private or gated models on HuggingFace, you need to provide an authentication token. For security best practices, you can store your HuggingFace token in AWS Secrets Manager or SSM secure string and pass it to both the compiler and inference environments:
 
 ```ts
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as s3 from "aws-cdk-lib/aws-s3";
+import * as batch from "aws-cdk-lib/aws-batch";
 import { Secret } from "aws-cdk-lib/aws-secretsmanager";
 
 declare const vpc: ec2.Vpc;
 declare const bucket: s3.Bucket;
 
-// Create or reference an existing secret containing your HuggingFace token
-const hfTokenSecret = Secret.fromSecretNameV2(this, "HFTokenSecret", "my-huggingface-token");
+// Reference an existing secret containing your HuggingFace token
+const hfTokenSecret = Secret.fromSecretNameV2(
+  this,
+  "HFTokenSecret",
+  "my-huggingface-token",
+);
+const hfToken = batch.Secret.fromSecretsManager(secret, "readonlyToken");
 
 // Pass the secret to the compiler
 const compiler = new VllmNxdInferenceCompiler(this, "Compiler", {
@@ -78,7 +84,7 @@ const compiler = new VllmNxdInferenceCompiler(this, "Compiler", {
   bucket,
   model: Model.fromHuggingFace("example/example-7b-chat"),
   vllmArgs: {
-    hfToken: hfTokenSecret, // Pass the HF token secret here
+    hfToken, // Pass the HF token secret here
   },
 });
 

--- a/src/base/neuronx-compiler/neuronx-compiler.ts
+++ b/src/base/neuronx-compiler/neuronx-compiler.ts
@@ -51,7 +51,7 @@ export interface NeuronxCompilerProps {
   /**
    * Secrets to pass to the container.
    */
-  readonly secrets?: { [key: string]: Secret };
+  readonly secrets?: { [key: string]: batch.Secret };
   /**
    * S3 Prefix that compiled artifact uploaded.
    * This property is not depends on compile job finish.

--- a/src/base/neuronx-compiler/neuronx-compiler.ts
+++ b/src/base/neuronx-compiler/neuronx-compiler.ts
@@ -3,12 +3,6 @@ import * as batch from "aws-cdk-lib/aws-batch";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { ContainerImage } from "aws-cdk-lib/aws-ecs";
 import { Grant } from "aws-cdk-lib/aws-iam";
-import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
-
-/**
- * Import types from aws-cdk-lib batch module
- */
-import * as batch from "aws-cdk-lib/aws-batch";
 
 /**
  * Secret type for container definition.

--- a/src/base/neuronx-compiler/neuronx-compiler.ts
+++ b/src/base/neuronx-compiler/neuronx-compiler.ts
@@ -3,8 +3,6 @@ import * as batch from "aws-cdk-lib/aws-batch";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { ContainerImage } from "aws-cdk-lib/aws-ecs";
 import { Grant } from "aws-cdk-lib/aws-iam";
-
-
 import { Code, Runtime, SingletonFunction } from "aws-cdk-lib/aws-lambda";
 import { IBucket } from "aws-cdk-lib/aws-s3";
 import { Provider } from "aws-cdk-lib/custom-resources";

--- a/src/base/neuronx-compiler/neuronx-compiler.ts
+++ b/src/base/neuronx-compiler/neuronx-compiler.ts
@@ -2,13 +2,18 @@ import { CustomResource, Duration, Size, Tags } from "aws-cdk-lib";
 import * as batch from "aws-cdk-lib/aws-batch";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { ContainerImage } from "aws-cdk-lib/aws-ecs";
-import { Grant, IRole } from "aws-cdk-lib/aws-iam";
+import { Grant } from "aws-cdk-lib/aws-iam";
 import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
+
+/**
+ * Import types from aws-cdk-lib batch module
+ */
+import * as batch from "aws-cdk-lib/aws-batch";
 
 /**
  * Secret type for container definition.
  */
-export type Secret = ISecret | string;
+export type Secret = batch.Secret;
 import { Code, Runtime, SingletonFunction } from "aws-cdk-lib/aws-lambda";
 import { IBucket } from "aws-cdk-lib/aws-s3";
 import { Provider } from "aws-cdk-lib/custom-resources";

--- a/src/base/neuronx-compiler/neuronx-compiler.ts
+++ b/src/base/neuronx-compiler/neuronx-compiler.ts
@@ -4,10 +4,7 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { ContainerImage } from "aws-cdk-lib/aws-ecs";
 import { Grant } from "aws-cdk-lib/aws-iam";
 
-/**
- * Secret type for container definition.
- */
-export type Secret = batch.Secret;
+
 import { Code, Runtime, SingletonFunction } from "aws-cdk-lib/aws-lambda";
 import { IBucket } from "aws-cdk-lib/aws-s3";
 import { Provider } from "aws-cdk-lib/custom-resources";

--- a/src/base/neuronx-compiler/neuronx-compiler.ts
+++ b/src/base/neuronx-compiler/neuronx-compiler.ts
@@ -2,7 +2,13 @@ import { CustomResource, Duration, Size, Tags } from "aws-cdk-lib";
 import * as batch from "aws-cdk-lib/aws-batch";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { ContainerImage } from "aws-cdk-lib/aws-ecs";
-import { Grant } from "aws-cdk-lib/aws-iam";
+import { Grant, IRole } from "aws-cdk-lib/aws-iam";
+import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
+
+/**
+ * Secret type for container definition.
+ */
+export type Secret = ISecret | string;
 import { Code, Runtime, SingletonFunction } from "aws-cdk-lib/aws-lambda";
 import { IBucket } from "aws-cdk-lib/aws-s3";
 import { Provider } from "aws-cdk-lib/custom-resources";
@@ -46,6 +52,10 @@ export interface NeuronxCompilerProps {
    * The bucket to upload compiled artifacts.
    */
   readonly bucket: IBucket;
+  /**
+   * Secrets to pass to the container.
+   */
+  readonly secrets?: { [key: string]: Secret };
   /**
    * S3 Prefix that compiled artifact uploaded.
    * This property is not depends on compile job finish.
@@ -201,6 +211,7 @@ export class NeuronxCompiler extends Construct {
         cpu: neuronxInstanceType.vCpu,
         environment: props.environment,
         command: props.command,
+        secrets: props.secrets,
       },
     );
 

--- a/src/base/server-engine/vllm-engine/vllm-engine-argments.test.ts
+++ b/src/base/server-engine/vllm-engine/vllm-engine-argments.test.ts
@@ -77,7 +77,6 @@ describe("VllmEngineArgumentsToConfig", () => {
       quantization: Quantization.AWQ,
       ropeScaling: {},
       ropeTheta: 1.0,
-      hfToken: true,
       hfOverrides: {},
       enforceEager: true,
       maxSeqLenToCapture: 4096,

--- a/src/base/server-engine/vllm-engine/vllm-engine-argments.test.ts
+++ b/src/base/server-engine/vllm-engine/vllm-engine-argments.test.ts
@@ -1,3 +1,6 @@
+import { App, Stack } from "aws-cdk-lib";
+import * as batch from "aws-cdk-lib/aws-batch";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
 import {
   ChatTemplateContentFormat,
   ConfigFormat,
@@ -21,11 +24,16 @@ import {
   VllmEngineArgumentsParser,
   VllmTask,
 } from "./vllm-engine-argments";
-import { Secret } from "aws-cdk-lib/aws-secretsmanager";
 
 describe("VllmEngineArgumentsToConfig", () => {
+  const app = new App();
+  const stack = new Stack(app);
+  const secret = Secret.fromSecretNameV2(
+    stack,
+    "DummySecret",
+    "huggingface-token",
+  );
   it("should convert all camelCase properties to kebab-case", () => {
-    // 全てのプロパティを含むテスト用オブジェクト
     const testObj: VllmEngineArguments = {
       host: "localhost",
       port: 8080,
@@ -78,20 +86,7 @@ describe("VllmEngineArgumentsToConfig", () => {
       quantization: Quantization.AWQ,
       ropeScaling: {},
       ropeTheta: 1.0,
-      hfToken: Secret.fromSecretNameV2(
-        {
-          node: {
-            id: "MockConstruct",
-            path: "Mock/Construct",
-            tryGetContext: () => undefined,
-            addError: () => {},
-            addWarning: () => {},
-            addInfo: () => {},
-          },
-        } as any,
-        "MockSecret",
-        "huggingface-token"
-      ),
+      hfToken: batch.Secret.fromSecretsManager(secret),
       hfOverrides: {},
       enforceEager: true,
       maxSeqLenToCapture: 4096,
@@ -177,7 +172,6 @@ describe("VllmEngineArgumentsToConfig", () => {
 
     const result = VllmEngineArgumentsParser.config(testObj);
 
-    // 変換結果の検証
     expect(result).toMatchObject({
       host: "localhost",
       port: 8080,
@@ -211,6 +205,8 @@ describe("VllmEngineArgumentsToConfig", () => {
       // model: "model-name",
       task: "generate",
       tokenizer: "tokenizer-name",
+      // should ignore the hf-token property
+      // "hf-token": "dummy",
       "hf-config-path": "config.json",
       "skip-tokenizer-init": true,
       revision: "v1.0",

--- a/src/base/server-engine/vllm-engine/vllm-engine-argments.test.ts
+++ b/src/base/server-engine/vllm-engine/vllm-engine-argments.test.ts
@@ -21,6 +21,7 @@ import {
   VllmEngineArgumentsParser,
   VllmTask,
 } from "./vllm-engine-argments";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
 
 describe("VllmEngineArgumentsToConfig", () => {
   it("should convert all camelCase properties to kebab-case", () => {
@@ -77,6 +78,20 @@ describe("VllmEngineArgumentsToConfig", () => {
       quantization: Quantization.AWQ,
       ropeScaling: {},
       ropeTheta: 1.0,
+      hfToken: Secret.fromSecretNameV2(
+        {
+          node: {
+            id: "MockConstruct",
+            path: "Mock/Construct",
+            tryGetContext: () => undefined,
+            addError: () => {},
+            addWarning: () => {},
+            addInfo: () => {},
+          },
+        } as any,
+        "MockSecret",
+        "huggingface-token"
+      ),
       hfOverrides: {},
       enforceEager: true,
       maxSeqLenToCapture: 4096,
@@ -217,7 +232,6 @@ describe("VllmEngineArgumentsToConfig", () => {
       quantization: "awq",
       "rope-scaling": "{}",
       "rope-theta": 1.0,
-      "hf-token": true,
       "hf-overrides": "{}",
       "enforce-eager": true,
       "max-seq-len-to-capture": 4096,

--- a/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
+++ b/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
@@ -619,9 +619,10 @@ export interface VllmNamedArguments {
 
   /**
    * The token to use as HTTP bearer authorization for remote files.
-   * If True, will use the token generated when running huggingface-cli login (stored in ~/.huggingface)..
+   * If a Secret is provided, it will be passed as HF_TOKEN environment variable.
+   * If True, will use the token generated when running huggingface-cli login (stored in ~/.huggingface).
    */
-  readonly hfToken?: boolean;
+  readonly hfToken?: boolean | import("aws-cdk-lib/aws-secretsmanager").ISecret;
 
   /**
    * Extra arguments for the HuggingFace config.
@@ -1259,6 +1260,10 @@ export abstract class VllmEngineArgumentsParser {
       .filter(([key]) => key !== "model")
       .reduce<{ [key in string]: any }>((prev, [key, value]) => {
         const k = key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+        // Skip ISecret objects as they will be handled through environment variables
+        if (typeof value === "object" && value && "secretArn" in value) {
+          return prev;
+        }
         if (
           jsonValueProperties.includes(key as keyof VllmEngineArguments) ||
           (!Array.isArray(value) && typeof value === "object")
@@ -1274,6 +1279,10 @@ export abstract class VllmEngineArgumentsParser {
       .filter(([key]) => key !== "model")
       .flatMap(([k, value]) => {
         const key = k.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+        // Skip ISecret objects as they will be handled through environment variables
+        if (typeof value === "object" && value && "secretArn" in value) {
+          return [];
+        }
         if (typeof value === "boolean") {
           return value ? [`--${key}`] : [];
         }

--- a/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
+++ b/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
@@ -619,10 +619,12 @@ export interface VllmNamedArguments {
 
   /**
    * The token to use as HTTP bearer authorization for remote files.
-   * If a Secret is provided, it will be passed as HF_TOKEN environment variable.
-   * If True, will use the token generated when running huggingface-cli login (stored in ~/.huggingface).
+   * If provided, the Secret will be passed as HF_TOKEN environment variable.
+   * 
+   * To use the token generated when running huggingface-cli login (stored in ~/.huggingface),
+   * set the `--hf-token` flag directly in the command line arguments.
    */
-  readonly hfToken?: boolean | import("aws-cdk-lib/aws-secretsmanager").ISecret;
+  readonly hfToken?: import("aws-cdk-lib/aws-secretsmanager").ISecret;
 
   /**
    * Extra arguments for the HuggingFace config.
@@ -1260,8 +1262,8 @@ export abstract class VllmEngineArgumentsParser {
       .filter(([key]) => key !== "model")
       .reduce<{ [key in string]: any }>((prev, [key, value]) => {
         const k = key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
-        // Skip ISecret objects as they will be handled through environment variables
-        if (typeof value === "object" && value && "secretArn" in value) {
+        // Skip Secret objects as they will be handled through environment variables
+        if (key === "hfToken" && value) {
           return prev;
         }
         if (
@@ -1279,8 +1281,8 @@ export abstract class VllmEngineArgumentsParser {
       .filter(([key]) => key !== "model")
       .flatMap(([k, value]) => {
         const key = k.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
-        // Skip ISecret objects as they will be handled through environment variables
-        if (typeof value === "object" && value && "secretArn" in value) {
+        // Skip Secret objects as they will be handled through environment variables
+        if (key === "hfToken" && value) {
           return [];
         }
         if (typeof value === "boolean") {

--- a/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
+++ b/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
@@ -1264,8 +1264,8 @@ export abstract class VllmEngineArgumentsParser {
       .filter(([key]) => key !== "model")
       .reduce<{ [key in string]: any }>((prev, [key, value]) => {
         const k = key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
-        // Skip Secret objects as they will be handled through environment variables
-        if (key === "hfToken" && value) {
+        // Skip hfToken as it will be handled through environment variables
+        if (key === "hfToken") {
           return prev;
         }
         if (
@@ -1283,8 +1283,8 @@ export abstract class VllmEngineArgumentsParser {
       .filter(([key]) => key !== "model")
       .flatMap(([k, value]) => {
         const key = k.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
-        // Skip Secret objects as they will be handled through environment variables
-        if (key === "hfToken" && value) {
+        // Skip hfToken as it will be handled through environment variables
+        if (key === "hfToken") {
           return [];
         }
         if (typeof value === "boolean") {

--- a/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
+++ b/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
@@ -1,4 +1,4 @@
-import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
+import { Secret } from "aws-cdk-lib/aws-batch";
 
 /**
  * Log level options for Uvicorn
@@ -621,12 +621,9 @@ export interface VllmNamedArguments {
 
   /**
    * The token to use as HTTP bearer authorization for remote files.
-   * If provided, the Secret will be passed as HF_TOKEN environment variable.
-   * 
-   * To use the token generated when running huggingface-cli login (stored in ~/.huggingface),
-   * set the `--hf-token` flag directly in the command line arguments.
+   * If provided, the Secret will be passed as HF_TOKEN secret to compile environment.
    */
-  readonly hfToken?: ISecret;
+  readonly hfToken?: Secret;
 
   /**
    * Extra arguments for the HuggingFace config.
@@ -1251,6 +1248,7 @@ const jsonValueProperties: (keyof VllmEngineArguments)[] = [
   "allowedHeaders",
   "allowedMethods",
 ];
+const ignoreKeys: (keyof VllmEngineArguments)[] = ["model", "hfToken"];
 
 export abstract class VllmEngineArgumentsParser {
   /**
@@ -1261,13 +1259,9 @@ export abstract class VllmEngineArgumentsParser {
    */
   static config(args: VllmEngineArguments) {
     return Object.entries(args)
-      .filter(([key]) => key !== "model")
+      .filter(([key]) => !ignoreKeys.includes(key as keyof VllmEngineArguments))
       .reduce<{ [key in string]: any }>((prev, [key, value]) => {
         const k = key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
-        // Skip hfToken as it will be handled through environment variables
-        if (key === "hfToken") {
-          return prev;
-        }
         if (
           jsonValueProperties.includes(key as keyof VllmEngineArguments) ||
           (!Array.isArray(value) && typeof value === "object")
@@ -1280,13 +1274,9 @@ export abstract class VllmEngineArgumentsParser {
   }
   static cli(args: VllmEngineArguments) {
     return Object.entries(args)
-      .filter(([key]) => key !== "model")
+      .filter(([key]) => !ignoreKeys.includes(key as keyof VllmEngineArguments))
       .flatMap(([k, value]) => {
         const key = k.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
-        // Skip hfToken as it will be handled through environment variables
-        if (key === "hfToken") {
-          return [];
-        }
         if (typeof value === "boolean") {
           return value ? [`--${key}`] : [];
         }

--- a/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
+++ b/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
@@ -1,3 +1,5 @@
+import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
+
 /**
  * Log level options for Uvicorn
  */
@@ -624,7 +626,7 @@ export interface VllmNamedArguments {
    * To use the token generated when running huggingface-cli login (stored in ~/.huggingface),
    * set the `--hf-token` flag directly in the command line arguments.
    */
-  readonly hfToken?: import("aws-cdk-lib/aws-secretsmanager").ISecret;
+  readonly hfToken?: ISecret;
 
   /**
    * Extra arguments for the HuggingFace config.

--- a/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
@@ -193,7 +193,6 @@ export class VllmNxdInferenceCompiler extends Construct {
       createHash("sha256").update(str).digest("hex");
     const artifactS3Prefix = `sdk-${image.sdkVersion}/${hash(JSON.stringify(vllmArgs))}`;
     const vllmCliArgs = VllmEngineArgumentsParser.cli(vllmArgs);
-    // Prepare environment and secrets
     const environment: Record<string, string> = {
       ...props.environment,
       VLLM_NEURON_FRAMEWORK: "neuronx-distributed-inference",
@@ -203,7 +202,6 @@ export class VllmNxdInferenceCompiler extends Construct {
       MODEL_NAME: props.model.modelName,
       COMPILED_ARTIFACTS_S3_URI: props.bucket.s3UrlForObject(artifactS3Prefix),
     };
-    // Handle hfToken if provided
     const secrets: { [key: string]: batch.Secret } = {};
     if (props.vllmArgs?.hfToken) {
       secrets.HF_TOKEN = props.vllmArgs.hfToken;

--- a/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
@@ -1,11 +1,11 @@
 import { Size } from "aws-cdk-lib";
+import * as batch from "aws-cdk-lib/aws-batch";
 import { IVpc, SubnetSelection } from "aws-cdk-lib/aws-ec2";
 import { ContainerImage } from "aws-cdk-lib/aws-ecs";
 import { IBucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import { createHash } from "crypto";
 import { join } from "path";
-import * as batch from "aws-cdk-lib/aws-batch";
 import {
   calcMemoryFootprint,
   calcTensorParallel,
@@ -201,14 +201,12 @@ export class VllmNxdInferenceCompiler extends Construct {
       NEURON_RT_NUM_CORES: tensorParallelSize.toString(),
       MODEL_ID: props.model.modelId,
       MODEL_NAME: props.model.modelName,
-      COMPILED_ARTIFACTS_S3_URI:
-        props.bucket.s3UrlForObject(artifactS3Prefix),
+      COMPILED_ARTIFACTS_S3_URI: props.bucket.s3UrlForObject(artifactS3Prefix),
     };
-    
     // Handle hfToken if provided
     const secrets: { [key: string]: batch.Secret } = {};
     if (props.vllmArgs?.hfToken) {
-      secrets["HF_TOKEN"] = batch.Secret.fromSecretsManager(props.vllmArgs.hfToken);
+      secrets.HF_TOKEN = props.vllmArgs.hfToken;
     }
 
     const compiler = new NeuronxCompiler(this, "Resource", {

--- a/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
@@ -20,6 +20,7 @@ import {
   INeuronxContainerImage,
   NeuronxCompiledModel,
   NeuronxCompiler,
+  Secret,
 } from "../base/neuronx-compiler";
 import {
   VllmEngineArguments,
@@ -192,22 +193,32 @@ export class VllmNxdInferenceCompiler extends Construct {
       createHash("sha256").update(str).digest("hex");
     const artifactS3Prefix = `sdk-${image.sdkVersion}/${hash(JSON.stringify(vllmArgs))}`;
     const vllmCliArgs = VllmEngineArgumentsParser.cli(vllmArgs);
+    // Prepare environment and secrets
+    const environment: Record<string, string> = {
+      ...props.environment,
+      VLLM_NEURON_FRAMEWORK: "neuronx-distributed-inference",
+      NEURON_COMPILED_ARTIFACTS: "neuron-compiled-artifacts",
+      NEURON_RT_NUM_CORES: tensorParallelSize.toString(),
+      MODEL_ID: props.model.modelId,
+      MODEL_NAME: props.model.modelName,
+      COMPILED_ARTIFACTS_S3_URI:
+        props.bucket.s3UrlForObject(artifactS3Prefix),
+    };
+    
+    // Handle hfToken if it's a Secret
+    const secrets: { [key: string]: Secret } = {};
+    if (typeof props.vllmArgs?.hfToken === 'object' && props.vllmArgs?.hfToken && 'secretArn' in props.vllmArgs.hfToken) {
+      secrets["HF_TOKEN"] = props.vllmArgs.hfToken;
+    }
+
     const compiler = new NeuronxCompiler(this, "Resource", {
       ...props,
       neuronxInstanceType: availableInstancePatterns[0].neuronxInstanceType,
       artifactS3Prefix,
       image: image,
       command: vllmCliArgs,
-      environment: {
-        ...props.environment,
-        VLLM_NEURON_FRAMEWORK: "neuronx-distributed-inference",
-        NEURON_COMPILED_ARTIFACTS: "neuron-compiled-artifacts",
-        NEURON_RT_NUM_CORES: tensorParallelSize.toString(),
-        MODEL_ID: props.model.modelId,
-        MODEL_NAME: props.model.modelName,
-        COMPILED_ARTIFACTS_S3_URI:
-          props.bucket.s3UrlForObject(artifactS3Prefix),
-      },
+      environment,
+      secrets: Object.keys(secrets).length > 0 ? secrets : undefined,
     });
     this.vllmArgs = vllmArgs;
     this.compiler = compiler;

--- a/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
@@ -21,7 +21,6 @@ import {
   INeuronxContainerImage,
   NeuronxCompiledModel,
   NeuronxCompiler,
-  Secret,
 } from "../base/neuronx-compiler";
 import {
   VllmEngineArguments,
@@ -207,7 +206,7 @@ export class VllmNxdInferenceCompiler extends Construct {
     };
     
     // Handle hfToken if provided
-    const secrets: { [key: string]: Secret } = {};
+    const secrets: { [key: string]: batch.Secret } = {};
     if (props.vllmArgs?.hfToken) {
       secrets["HF_TOKEN"] = batch.Secret.fromSecretsManager(props.vllmArgs.hfToken);
     }

--- a/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
@@ -205,9 +205,9 @@ export class VllmNxdInferenceCompiler extends Construct {
         props.bucket.s3UrlForObject(artifactS3Prefix),
     };
     
-    // Handle hfToken if it's a Secret
+    // Handle hfToken if provided
     const secrets: { [key: string]: Secret } = {};
-    if (typeof props.vllmArgs?.hfToken === 'object' && props.vllmArgs?.hfToken && 'secretArn' in props.vllmArgs.hfToken) {
+    if (props.vllmArgs?.hfToken) {
       secrets["HF_TOKEN"] = props.vllmArgs.hfToken;
     }
 

--- a/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
@@ -218,7 +218,7 @@ export class VllmNxdInferenceCompiler extends Construct {
       image: image,
       command: vllmCliArgs,
       environment,
-      secrets: Object.keys(secrets).length > 0 ? secrets : undefined,
+      secrets,
     });
     this.vllmArgs = vllmArgs;
     this.compiler = compiler;

--- a/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-compiler.ts
@@ -5,6 +5,7 @@ import { IBucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import { createHash } from "crypto";
 import { join } from "path";
+import * as batch from "aws-cdk-lib/aws-batch";
 import {
   calcMemoryFootprint,
   calcTensorParallel,
@@ -208,7 +209,7 @@ export class VllmNxdInferenceCompiler extends Construct {
     // Handle hfToken if provided
     const secrets: { [key: string]: Secret } = {};
     if (props.vllmArgs?.hfToken) {
-      secrets["HF_TOKEN"] = props.vllmArgs.hfToken;
+      secrets["HF_TOKEN"] = batch.Secret.fromSecretsManager(props.vllmArgs.hfToken);
     }
 
     const compiler = new NeuronxCompiler(this, "Resource", {

--- a/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
@@ -127,9 +127,7 @@ export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
 
     // Handle secrets for HF Token if available
     const secrets: Record<string, ecs.Secret> = {};
-    if (typeof props.compiledModel.vllmArgs.hfToken === 'object' && 
-        props.compiledModel.vllmArgs.hfToken && 
-        'secretArn' in props.compiledModel.vllmArgs.hfToken) {
+    if (props.compiledModel.vllmArgs.hfToken) {
       secrets["HF_TOKEN"] = ecs.Secret.fromSecretsManager(props.compiledModel.vllmArgs.hfToken);
     }
 

--- a/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
@@ -147,7 +147,7 @@ export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
       },
       command: vllmCliArgs,
       environment,
-      secrets: Object.keys(secrets).length > 0 ? secrets : undefined,
+      secrets,
     });
   }
 }

--- a/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
@@ -125,12 +125,6 @@ export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
       COMPILED_ARTIFACTS_S3_URI: props.compiledModel.s3Uri,
     };
 
-    // Handle secrets for HF Token if available
-    const secrets: Record<string, ecs.Secret> = {};
-    if (props.compiledModel.vllmArgs.hfToken) {
-      secrets["HF_TOKEN"] = ecs.Secret.fromSecretsManager(props.compiledModel.vllmArgs.hfToken);
-    }
-
     this.addContainerWithDefault("vLLM", {
       image: image.image,
       portMappings: [
@@ -147,7 +141,6 @@ export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
       },
       command: vllmCliArgs,
       environment,
-      secrets,
     });
   }
 }

--- a/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
@@ -115,6 +115,24 @@ export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
     const vllmCliArgs = VllmEngineArgumentsParser.cli(
       props.compiledModel.vllmArgs,
     );
+    // Prepare environment variables
+    const environment: Record<string, string> = {
+      ...props.environment,
+      VLLM_NEURON_FRAMEWORK: "neuronx-distributed-inference",
+      NEURON_COMPILED_ARTIFACTS: "neuron-compiled-artifacts",
+      NEURON_RT_NUM_CORES: tensorParallelSize.toString(),
+      MODEL_NAME: props.compiledModel.modelName,
+      COMPILED_ARTIFACTS_S3_URI: props.compiledModel.s3Uri,
+    };
+
+    // Handle secrets for HF Token if available
+    const secrets: Record<string, ecs.Secret> = {};
+    if (typeof props.compiledModel.vllmArgs.hfToken === 'object' && 
+        props.compiledModel.vllmArgs.hfToken && 
+        'secretArn' in props.compiledModel.vllmArgs.hfToken) {
+      secrets["HF_TOKEN"] = ecs.Secret.fromSecretsManager(props.compiledModel.vllmArgs.hfToken);
+    }
+
     this.addContainerWithDefault("vLLM", {
       image: image.image,
       portMappings: [
@@ -130,14 +148,8 @@ export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
         startPeriod: Duration.minutes(5),
       },
       command: vllmCliArgs,
-      environment: {
-        ...props.environment,
-        VLLM_NEURON_FRAMEWORK: "neuronx-distributed-inference",
-        NEURON_COMPILED_ARTIFACTS: "neuron-compiled-artifacts",
-        NEURON_RT_NUM_CORES: tensorParallelSize.toString(),
-        MODEL_NAME: props.compiledModel.modelName,
-        COMPILED_ARTIFACTS_S3_URI: props.compiledModel.s3Uri,
-      },
+      environment,
+      secrets: Object.keys(secrets).length > 0 ? secrets : undefined,
     });
   }
 }


### PR DESCRIPTION
# Feature: Support for HuggingFace Token as Secret

## Description
This PR adds support for using HuggingFace tokens securely through AWS Secrets Manager. The token is passed as an environment variable to both the compiler (Batch) and inference environment (ECS).

## Changes
- Modified  to accept batch.Secret for the hfToken property
- Updated  to properly handle Secret objects
- Added support in the compiler to pass the secret to Batch jobs
- Added support in the ECS task definition to pass the secret to containers

## Usage
Users can now securely use their HuggingFace tokens as follows:



This allows secure handling of HuggingFace tokens without exposing them in environment variables or code.

Fix #11 

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_