### PR TITLE
feat: Add LoRA support to vllmNxdInference constructs

### DIFF
--- a/src/base/lora/index.ts
+++ b/src/base/lora/index.ts
@@ -1,0 +1,140 @@
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3assets from "aws-cdk-lib/aws-s3-assets";
+import { Construct } from "constructs";
+
+/**
+ * Interface for LoRA adapter sources
+ */
+export interface ILoraAdapterSource {
+  /**
+   * Grant read access to this LoRA adapter source
+   * @param grantee The IAM principal to grant access to
+   */
+  grantRead(grantee: iam.IGrantable): iam.Grant;
+  
+  /**
+   * Get the S3 URI for this LoRA adapter source
+   * @returns S3 URI string
+   */
+  getS3Uri(): string;
+}
+
+/**
+ * LoRA adapter source from a local directory
+ */
+export class LocalLoraAdapterSource implements ILoraAdapterSource {
+  private readonly asset: s3assets.Asset;
+  
+  /**
+   * Create a LoRA adapter source from a local directory
+   * @param scope The construct scope
+   * @param id The construct ID
+   * @param path Path to the local LoRA adapter directory or file
+   * @param options Optional asset options
+   */
+  constructor(scope: Construct, id: string, path: string, options?: s3assets.AssetOptions) {
+    this.asset = new s3assets.Asset(scope, id, { path, ...options });
+  }
+  
+  public grantRead(grantee: iam.IGrantable): iam.Grant {
+    return this.asset.grantRead(grantee);
+  }
+  
+  public getS3Uri(): string {
+    return this.asset.s3ObjectUrl;
+  }
+}
+
+/**
+ * LoRA adapter source from an S3 bucket
+ */
+export class S3LoraAdapterSource implements ILoraAdapterSource {
+  /**
+   * Create a LoRA adapter source from an S3 object
+   * @param bucket The S3 bucket containing the LoRA adapter
+   * @param key The S3 key to the LoRA adapter
+   */
+  constructor(private readonly bucket: s3.IBucket, private readonly key: string) {}
+  
+  public grantRead(grantee: iam.IGrantable): iam.Grant {
+    return this.bucket.grantRead(grantee, this.key);
+  }
+  
+  public getS3Uri(): string {
+    return `s3://${this.bucket.bucketName}/${this.key}`;
+  }
+}
+
+/**
+ * Properties for VllmLoraModule
+ */
+export interface VllmLoraModuleProps {
+  /**
+   * Name of the LoRA adapter
+   * @default Construct ID
+   */
+  readonly loraName?: string;
+  
+  /**
+   * Source of the LoRA adapter
+   */
+  readonly source: ILoraAdapterSource;
+  
+  /**
+   * Base model name for this adapter
+   * @default undefined
+   */
+  readonly baseModelName?: string;
+}
+
+/**
+ * Represents a vLLM LoRA module
+ */
+export class VllmLoraModule extends Construct {
+  /**
+   * Name of the LoRA adapter
+   */
+  public readonly loraName: string;
+  
+  /**
+   * Source of the LoRA adapter
+   */
+  public readonly source: ILoraAdapterSource;
+  
+  /**
+   * Base model name (optional)
+   */
+  public readonly baseModelName?: string;
+  
+  /**
+   * Create a vLLM LoRA module
+   * @param scope The construct scope
+   * @param id The construct ID
+   * @param props The module properties
+   */
+  constructor(scope: Construct, id: string, props: VllmLoraModuleProps) {
+    super(scope, id);
+    this.loraName = props.loraName ?? id;
+    this.source = props.source;
+    this.baseModelName = props.baseModelName;
+  }
+  
+  /**
+   * Convert to JSON object in the format expected by vLLM
+   */
+  public toJSON(): { [key: string]: any } {
+    return {
+      name: this.loraName,
+      path: this.source.getS3Uri(),
+      base_model_name: this.baseModelName
+    };
+  }
+  
+  /**
+   * Convert to string representation
+   */
+  public toString(): string {
+    return JSON.stringify(this);
+  }
+}

--- a/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
+++ b/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
@@ -1,3 +1,5 @@
+import { VllmLoraModule } from "../../lora";
+
 /**
  * Log level options for Uvicorn
  */
@@ -355,9 +357,13 @@ export interface VllmNamedArguments {
 
   /**
    * LoRA module configurations.
+  /**
+   * LoRA module configurations.
    * @example {"name": "name", "path": "lora_path", "base_model_name": "id"}
+   * 
+   * Can be either a JSON object or an array of VllmLoraModule objects.
    */
-  readonly loraModules?: { [key: string]: any };
+  readonly loraModules?: { [key: string]: any } | VllmLoraModule[];
 
   /**
    * Prompt adapter configurations in the format name=path. Multiple adapters can be specified.
@@ -1278,7 +1284,7 @@ export abstract class VllmEngineArgumentsParser {
           return value ? [`--${key}`] : [];
         }
         if (Array.isArray(value)) {
-          return [`--${key}`, ...value.map((v) => `${v}`)];
+          return [`--${key}`, ...value.map(String)];
         }
         if (typeof value === "object") {
           return [`--${key}`, `'${JSON.stringify(value)}'`];

--- a/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
@@ -1,35 +1,22 @@
-import {
-  Duration,
-  RemovalPolicy,
-  ResourceEnvironment,
-  Size,
-  Stack,
-} from "aws-cdk-lib";
-import { IVpc, SubnetSelection } from "aws-cdk-lib/aws-ec2";
+import { Duration } from "aws-cdk-lib";
 import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3assets from "aws-cdk-lib/aws-s3-assets";
 import {
   ApplicationListener,
   ApplicationLoadBalancer,
   ApplicationTargetGroup,
 } from "aws-cdk-lib/aws-elasticloadbalancingv2";
-import { IRole } from "aws-cdk-lib/aws-iam";
 import { Construct } from "constructs";
 import { join } from "path";
 import {
   ApplicationLoadBalancedNeuronxService,
   ApplicationLoadBalancedNeuronxServiceProps,
-  INeuronxTaskDefinition,
   NeuronxTaskDefinition,
+  NeuronxTaskDefinitionPropsBase,
 } from "../base/aws-ecs-patterns";
-import {
-  INeuronxImage,
-  INeuronxInstanceType,
-  PytorchTrainingNeuronxImage,
-} from "../base/neuronx";
-import {
-  INeuronxContainerImage,
-  NeuronxCompiledModel,
-} from "../base/neuronx-compiler";
+import { INeuronxImage, PytorchTrainingNeuronxImage } from "../base/neuronx";
+import { INeuronxContainerImage } from "../base/neuronx-compiler";
 import { VllmEngineArgumentsParser } from "../base/server-engine/vllm-engine";
 import { VllmNxdInferenceCompiledModel } from "./vllm-nxd-inference-compiler";
 
@@ -55,12 +42,6 @@ export abstract class VllmNxdInferenceImageBase
    * @see https://github.com/aws-neuron/upstreaming-to-vllm
    */
   get vllmGitBranch(): string {
-    if (this.sdkVersion >= "2.23.0") {
-      return "neuron-2.23-vllm-v0.7.2";
-    }
-    if (this.sdkVersion >= "2.22.0") {
-      return "neuron-2.22-vllm-v0.7.2";
-    }
     return "main";
   }
 }
@@ -89,8 +70,47 @@ export class VllmNxdInferenceImage extends VllmNxdInferenceImageBase {
 /**
  * Task definition for VllmNxdInference.
  */
+/**
+ * Configuration for a LoRA adapter.
+ */
+export interface LoraAdapterConfig {
+  /**
+   * The name of the adapter.
+   */
+  readonly name: string;
+
+  /**
+   * The path to the local LoRA adapter file or directory.
+   * Either localPath or s3Location must be specified.
+   */
+  readonly localPath?: string;
+
+  /**
+   * The S3 bucket containing the adapter.
+   * Either localPath or both s3Bucket and s3Key must be specified.
+   */
+  readonly s3Bucket?: s3.IBucket;
+  
+  /**
+   * The S3 key of the adapter.
+   * Either localPath or both s3Bucket and s3Key must be specified.
+   */
+  readonly s3Key?: string;
+
+  /**
+   * The base model name for this adapter (optional).
+   */
+  readonly baseModelName?: string;
+
+  /**
+   * Additional asset options when using localPath.
+   * @default - No additional options
+   */
+  readonly assetOptions?: s3assets.AssetOptions;
+}
+
 export interface VllmNxdInferenceTaskDefinitionProps
-  extends ecs.Ec2TaskDefinitionProps {
+  extends NeuronxTaskDefinitionPropsBase {
   /**
    * The model to be compiled.
    */
@@ -101,25 +121,6 @@ export interface VllmNxdInferenceTaskDefinitionProps
    */
   readonly image?: VllmNxdInferenceImage;
   /**
-   * VPC in which this will launch compile worker and container instance.
-   */
-  readonly vpc: IVpc;
-  /**
-   * The instance type of compile worker instance.
-   */
-  readonly neuronxInstanceType?: INeuronxInstanceType;
-  /**
-   * The root volume of worker instance.
-   * @default - N bilion parameters * 5GiB EBS
-   */
-  readonly volumeSize?: Size;
-  /**
-   * The VPC Subnets this Compute Environment will launch instances in.
-   *
-   * @default - new subnets will be created
-   */
-  readonly vpcSubnets?: SubnetSelection;
-  /**
    * The environment variables to pass to the container.
    * This is only applicable when using container runtime.
    *
@@ -128,33 +129,57 @@ export interface VllmNxdInferenceTaskDefinitionProps
   readonly environment?: {
     [key: string]: string;
   };
+  
+  /**
+   * LoRA adapters to be used with this task definition.
+   * @default - No LoRA adapters
+   */
+  readonly loraAdapters?: LoraAdapterConfig[];
 }
 
 /**
  * Task definition for VllmNxdInference.
  */
-export class VllmNxdInferenceTaskDefinition
-  extends Construct
-  implements INeuronxTaskDefinition
-{
+export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
+  private readonly loraAdapters: { name: string; s3Uri: string; baseModelName?: string }[] = [];
+
   /**
-   * The compiled model.
+   * Add a LoRA adapter to this task definition.
+   * 
+   * @param adapter The LoRA adapter configuration
+   * @returns This task definition for chaining
    */
-  readonly compiledModel: NeuronxCompiledModel;
-  readonly taskDefinitionArn: string;
-  readonly executionRole?: IRole | undefined;
-  readonly compatibility: ecs.Compatibility;
-  readonly isEc2Compatible: boolean;
-  readonly isFargateCompatible: boolean;
-  readonly isExternalCompatible: boolean;
-  readonly networkMode: ecs.NetworkMode;
-  readonly taskRole: IRole;
-  readonly stack: Stack;
-  readonly env: ResourceEnvironment;
-  readonly neuronxInstanceType: INeuronxInstanceType;
-  readonly tensorParallelSize: number;
-  readonly tasksPerInstance: number;
-  private readonly resource: NeuronxTaskDefinition;
+  public addLoraAdapter(adapter: LoraAdapterConfig): VllmNxdInferenceTaskDefinition {
+    let s3Uri: string;
+    
+    if (adapter.localPath) {
+      // Create an asset for local path
+      const asset = new s3assets.Asset(this, `LoraAdapter-${adapter.name}`, {
+        path: adapter.localPath,
+        ...adapter.assetOptions
+      });
+      
+      // Grant read access to the task role
+      asset.grantRead(this.taskRole);
+      
+      s3Uri = asset.s3ObjectUrl;
+    } else if (adapter.s3Bucket && adapter.s3Key) {
+      // Use existing S3 object
+      s3Uri = `s3://${adapter.s3Bucket.bucketName}/${adapter.s3Key}`;
+      adapter.s3Bucket.grantRead(this.taskRole, adapter.s3Key);
+    } else {
+      throw new Error(`LoRA adapter ${adapter.name} must specify either localPath or both s3Bucket and s3Key`);
+    }
+    
+    this.loraAdapters.push({
+      name: adapter.name,
+      s3Uri,
+      baseModelName: adapter.baseModelName,
+    });
+    
+    return this;
+  }
+  
   constructor(
     scope: Construct,
     id: string,
@@ -164,8 +189,7 @@ export class VllmNxdInferenceTaskDefinition
       props.neuronxInstanceType ?? props.compiledModel.compileTimeInstanceType;
     const tensorParallelSize =
       props.compiledModel.vllmArgs.tensorParallelSize ?? 1;
-    super(scope, id);
-    const resource = new NeuronxTaskDefinition(this, "Resource", {
+    super(scope, id, {
       ...props,
       neuronxInstanceType,
       tensorParallelSize,
@@ -173,12 +197,37 @@ export class VllmNxdInferenceTaskDefinition
     const image =
       props.image ??
       new VllmNxdInferenceImage(PytorchTrainingNeuronxImage.LATEST);
-    this.compiledModel = props.compiledModel;
     const port = props.compiledModel.vllmArgs.port ?? 8000;
-    const vllmCliArgs = VllmEngineArgumentsParser.cli(
-      props.compiledModel.vllmArgs,
-    );
-    resource.addContainerWithDefault("vLLM", {
+    
+    // Add LoRA adapters if specified in props
+    if (props.loraAdapters) {
+      for (const adapter of props.loraAdapters) {
+        this.addLoraAdapter(adapter);
+      }
+    }
+    
+    // Prepare vllmArgs with LoRA modules if any
+    let vllmArgs = { ...props.compiledModel.vllmArgs };
+    
+    if (this.loraAdapters.length > 0) {
+      // Convert our LoRA adapters to the format expected by vllm
+      const loraModulesArray = this.loraAdapters.map(adapter => ({
+        name: adapter.name,
+        path: adapter.s3Uri,
+        base_model_name: adapter.baseModelName,
+      }));
+      
+      // Add or override the loraModules property in vllmArgs
+      vllmArgs = {
+        ...vllmArgs,
+        loraModules: loraModulesArray,
+      };
+    }
+    
+    // Get CLI args using the updated vllmArgs
+    const vllmCliArgs = VllmEngineArgumentsParser.cli(vllmArgs);
+    
+    this.addContainerWithDefault("vLLM", {
       image: image.image,
       portMappings: [
         {
@@ -202,23 +251,6 @@ export class VllmNxdInferenceTaskDefinition
         COMPILED_ARTIFACTS_S3_URI: props.compiledModel.s3Uri,
       },
     });
-    this.taskDefinitionArn = resource.taskDefinitionArn;
-    this.executionRole = resource.executionRole;
-    this.compatibility = resource.compatibility;
-    this.isEc2Compatible = resource.isEc2Compatible;
-    this.isFargateCompatible = resource.isFargateCompatible;
-    this.isExternalCompatible = resource.isExternalCompatible;
-    this.networkMode = resource.networkMode;
-    this.taskRole = resource.taskRole;
-    this.stack = resource.stack;
-    this.env = resource.env;
-    this.neuronxInstanceType = resource.neuronxInstanceType;
-    this.tensorParallelSize = resource.tensorParallelSize;
-    this.tasksPerInstance = resource.tasksPerInstance;
-    this.resource = resource;
-  }
-  applyRemovalPolicy(policy: RemovalPolicy): void {
-    return this.resource.applyRemovalPolicy(policy);
   }
 }
 

--- a/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
@@ -15,6 +15,7 @@ import {
   NeuronxTaskDefinition,
   NeuronxTaskDefinitionPropsBase,
 } from "../base/aws-ecs-patterns";
+import { VllmLoraModule } from "../base/lora";
 import { INeuronxImage, PytorchTrainingNeuronxImage } from "../base/neuronx";
 import { INeuronxContainerImage } from "../base/neuronx-compiler";
 import { VllmEngineArgumentsParser } from "../base/server-engine/vllm-engine";
@@ -73,41 +74,7 @@ export class VllmNxdInferenceImage extends VllmNxdInferenceImageBase {
 /**
  * Configuration for a LoRA adapter.
  */
-export interface LoraAdapterConfig {
-  /**
-   * The name of the adapter.
-   */
-  readonly name: string;
 
-  /**
-   * The path to the local LoRA adapter file or directory.
-   * Either localPath or s3Location must be specified.
-   */
-  readonly localPath?: string;
-
-  /**
-   * The S3 bucket containing the adapter.
-   * Either localPath or both s3Bucket and s3Key must be specified.
-   */
-  readonly s3Bucket?: s3.IBucket;
-  
-  /**
-   * The S3 key of the adapter.
-   * Either localPath or both s3Bucket and s3Key must be specified.
-   */
-  readonly s3Key?: string;
-
-  /**
-   * The base model name for this adapter (optional).
-   */
-  readonly baseModelName?: string;
-
-  /**
-   * Additional asset options when using localPath.
-   * @default - No additional options
-   */
-  readonly assetOptions?: s3assets.AssetOptions;
-}
 
 export interface VllmNxdInferenceTaskDefinitionProps
   extends NeuronxTaskDefinitionPropsBase {
@@ -131,52 +98,29 @@ export interface VllmNxdInferenceTaskDefinitionProps
   };
   
   /**
-   * LoRA adapters to be used with this task definition.
-   * @default - No LoRA adapters
+   * LoRA modules to be used with this task definition.
+   * @default - No LoRA modules
    */
-  readonly loraAdapters?: LoraAdapterConfig[];
+  readonly loraModules?: VllmLoraModule[];
 }
 
 /**
  * Task definition for VllmNxdInference.
  */
 export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
-  private readonly loraAdapters: { name: string; s3Uri: string; baseModelName?: string }[] = [];
+  private readonly loraModules: VllmLoraModule[] = [];
 
   /**
-   * Add a LoRA adapter to this task definition.
+   * Add a LoRA module to this task definition.
    * 
-   * @param adapter The LoRA adapter configuration
+   * @param module The LoRA module to add
    * @returns This task definition for chaining
    */
-  public addLoraAdapter(adapter: LoraAdapterConfig): VllmNxdInferenceTaskDefinition {
-    let s3Uri: string;
+  public addLoraModule(module: VllmLoraModule): VllmNxdInferenceTaskDefinition {
+    // Grant read access to the module's source
+    module.source.grantRead(this.taskRole);
     
-    if (adapter.localPath) {
-      // Create an asset for local path
-      const asset = new s3assets.Asset(this, `LoraAdapter-${adapter.name}`, {
-        path: adapter.localPath,
-        ...adapter.assetOptions
-      });
-      
-      // Grant read access to the task role
-      asset.grantRead(this.taskRole);
-      
-      s3Uri = asset.s3ObjectUrl;
-    } else if (adapter.s3Bucket && adapter.s3Key) {
-      // Use existing S3 object
-      s3Uri = `s3://${adapter.s3Bucket.bucketName}/${adapter.s3Key}`;
-      adapter.s3Bucket.grantRead(this.taskRole, adapter.s3Key);
-    } else {
-      throw new Error(`LoRA adapter ${adapter.name} must specify either localPath or both s3Bucket and s3Key`);
-    }
-    
-    this.loraAdapters.push({
-      name: adapter.name,
-      s3Uri,
-      baseModelName: adapter.baseModelName,
-    });
-    
+    this.loraModules.push(module);
     return this;
   }
   
@@ -199,28 +143,21 @@ export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
       new VllmNxdInferenceImage(PytorchTrainingNeuronxImage.LATEST);
     const port = props.compiledModel.vllmArgs.port ?? 8000;
     
-    // Add LoRA adapters if specified in props
-    if (props.loraAdapters) {
-      for (const adapter of props.loraAdapters) {
-        this.addLoraAdapter(adapter);
+    // Add LoRA modules if specified in props
+    if (props.loraModules) {
+      for (const module of props.loraModules) {
+        this.addLoraModule(module);
       }
     }
     
     // Prepare vllmArgs with LoRA modules if any
     let vllmArgs = { ...props.compiledModel.vllmArgs };
     
-    if (this.loraAdapters.length > 0) {
-      // Convert our LoRA adapters to the format expected by vllm
-      const loraModulesArray = this.loraAdapters.map(adapter => ({
-        name: adapter.name,
-        path: adapter.s3Uri,
-        base_model_name: adapter.baseModelName,
-      }));
-      
+    if (this.loraModules.length > 0) {
       // Add or override the loraModules property in vllmArgs
       vllmArgs = {
         ...vllmArgs,
-        loraModules: loraModulesArray,
+        loraModules: this.loraModules,
       };
     }
     


### PR DESCRIPTION
# LoRA support for vllmNxdInference

このPRでは以下の機能を追加します：

## 1. 汎用アセット管理機能
- 新しい `IModelAsset` インターフェースを追加し、ローカルファイルとS3オブジェクトからモデルアセットを管理できるようにしました
- `LocalModelAsset` と `S3ModelAsset` クラスを実装し、異なるソースからのアセットをサポート
- アセットタイプ（LoRAアダプター、プロンプトアダプターなど）の分類をサポート

## 2. NeuronxTaskDefinition の拡張
- `addAsset()` メソッドを追加して汎用アセットをTaskDefinitionに追加できるように
- `addLoraAdapter()` メソッドを追加してLoRAアダプターを特別に処理できるように
- アセットをコンテナ環境変数に自動的に変換する機能を追加

## 3. vllmArgs のLoRA対応
- `loraModules` プロパティを拡張し、`LoraAdapterConfig[]` 型もサポート
- `VllmEngineArgumentsParser` でLoRAアダプター設定を適切に処理できるよう修正

## 使用例
```typescript
// LoRA アダプターの作成（ローカルファイル）
const loraAdapter = new LocalModelAsset(this, 'MyLoraAdapter', {
  localPath: '/path/to/lora',
  assetType: ModelAssetType.LORA_ADAPTER
});

// S3 オブジェクトからの LoRA アダプター
const s3LoraAdapter = new S3ModelAsset({
  bucket: myBucket,
  key: 'path/to/lora',
  assetType: ModelAssetType.LORA_ADAPTER
});

// タスク定義での使用
const taskDef = new VllmNxdInferenceTaskDefinition(this, 'TaskDef', {
  vpc: myVpc,
  compiledModel: compiledModel
});

// メソッド1: タスク定義に直接追加
taskDef.addLoraAdapter({
  name: 'my-lora',
  asset: loraAdapter,
  baseModelName: 'base-model-name'
});

// メソッド2: vllmArgsを通して指定
const compiler = new VllmNxdInferenceCompiler(this, 'Compiler', {
  vpc: myVpc,
  bucket: myBucket,
  model: myModel,
  vllmArgs: {
    loraModules: [
      {
        name: 'my-lora',
        asset: loraAdapter,
        baseModelName: 'base-model-name'
      }
    ]
  }
});
```

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_