### PR TITLE
feat: Add LoRA support to vllmNxdInference constructs (simplified)

### DIFF
--- a/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
@@ -86,20 +86,16 @@ export interface LoraAdapterConfig {
   readonly localPath?: string;
 
   /**
-   * The S3 location of the LoRA adapter.
-   * Either localPath or s3Location must be specified.
+   * The S3 bucket containing the adapter.
+   * Either localPath or both s3Bucket and s3Key must be specified.
    */
-  readonly s3Location?: {
-    /**
-     * The S3 bucket containing the adapter.
-     */
-    readonly bucket: s3.IBucket;
-    
-    /**
-     * The S3 key of the adapter.
-     */
-    readonly key: string;
-  };
+  readonly s3Bucket?: s3.IBucket;
+  
+  /**
+   * The S3 key of the adapter.
+   * Either localPath or both s3Bucket and s3Key must be specified.
+   */
+  readonly s3Key?: string;
 
   /**
    * The base model name for this adapter (optional).
@@ -167,12 +163,12 @@ export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
       asset.grantRead(this.taskRole);
       
       s3Uri = asset.s3ObjectUrl;
-    } else if (adapter.s3Location) {
+    } else if (adapter.s3Bucket && adapter.s3Key) {
       // Use existing S3 object
-      s3Uri = `s3://${adapter.s3Location.bucket.bucketName}/${adapter.s3Location.key}`;
-      adapter.s3Location.bucket.grantRead(this.taskRole, adapter.s3Location.key);
+      s3Uri = `s3://${adapter.s3Bucket.bucketName}/${adapter.s3Key}`;
+      adapter.s3Bucket.grantRead(this.taskRole, adapter.s3Key);
     } else {
-      throw new Error(`LoRA adapter ${adapter.name} must specify either localPath or s3Location`);
+      throw new Error(`LoRA adapter ${adapter.name} must specify either localPath or both s3Bucket and s3Key`);
     }
     
     this.loraAdapters.push({

--- a/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
@@ -1,5 +1,7 @@
 import { Duration } from "aws-cdk-lib";
 import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3assets from "aws-cdk-lib/aws-s3-assets";
 import {
   ApplicationListener,
   ApplicationLoadBalancer,
@@ -68,6 +70,49 @@ export class VllmNxdInferenceImage extends VllmNxdInferenceImageBase {
 /**
  * Task definition for VllmNxdInference.
  */
+/**
+ * Configuration for a LoRA adapter.
+ */
+export interface LoraAdapterConfig {
+  /**
+   * The name of the adapter.
+   */
+  readonly name: string;
+
+  /**
+   * The path to the local LoRA adapter file or directory.
+   * Either localPath or s3Location must be specified.
+   */
+  readonly localPath?: string;
+
+  /**
+   * The S3 location of the LoRA adapter.
+   * Either localPath or s3Location must be specified.
+   */
+  readonly s3Location?: {
+    /**
+     * The S3 bucket containing the adapter.
+     */
+    readonly bucket: s3.IBucket;
+    
+    /**
+     * The S3 key of the adapter.
+     */
+    readonly key: string;
+  };
+
+  /**
+   * The base model name for this adapter (optional).
+   */
+  readonly baseModelName?: string;
+
+  /**
+   * Additional asset options when using localPath.
+   * @default - No additional options
+   */
+  readonly assetOptions?: s3assets.AssetOptions;
+}
+
 export interface VllmNxdInferenceTaskDefinitionProps
   extends NeuronxTaskDefinitionPropsBase {
   /**
@@ -88,12 +133,57 @@ export interface VllmNxdInferenceTaskDefinitionProps
   readonly environment?: {
     [key: string]: string;
   };
+  
+  /**
+   * LoRA adapters to be used with this task definition.
+   * @default - No LoRA adapters
+   */
+  readonly loraAdapters?: LoraAdapterConfig[];
 }
 
 /**
  * Task definition for VllmNxdInference.
  */
 export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
+  private readonly loraAdapters: { name: string; s3Uri: string; baseModelName?: string }[] = [];
+
+  /**
+   * Add a LoRA adapter to this task definition.
+   * 
+   * @param adapter The LoRA adapter configuration
+   * @returns This task definition for chaining
+   */
+  public addLoraAdapter(adapter: LoraAdapterConfig): VllmNxdInferenceTaskDefinition {
+    let s3Uri: string;
+    
+    if (adapter.localPath) {
+      // Create an asset for local path
+      const asset = new s3assets.Asset(this, `LoraAdapter-${adapter.name}`, {
+        path: adapter.localPath,
+        ...adapter.assetOptions
+      });
+      
+      // Grant read access to the task role
+      asset.grantRead(this.taskRole);
+      
+      s3Uri = asset.s3ObjectUrl;
+    } else if (adapter.s3Location) {
+      // Use existing S3 object
+      s3Uri = `s3://${adapter.s3Location.bucket.bucketName}/${adapter.s3Location.key}`;
+      adapter.s3Location.bucket.grantRead(this.taskRole, adapter.s3Location.key);
+    } else {
+      throw new Error(`LoRA adapter ${adapter.name} must specify either localPath or s3Location`);
+    }
+    
+    this.loraAdapters.push({
+      name: adapter.name,
+      s3Uri,
+      baseModelName: adapter.baseModelName,
+    });
+    
+    return this;
+  }
+  
   constructor(
     scope: Construct,
     id: string,
@@ -112,9 +202,35 @@ export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
       props.image ??
       new VllmNxdInferenceImage(PytorchTrainingNeuronxImage.LATEST);
     const port = props.compiledModel.vllmArgs.port ?? 8000;
-    const vllmCliArgs = VllmEngineArgumentsParser.cli(
-      props.compiledModel.vllmArgs,
-    );
+    
+    // Add LoRA adapters if specified in props
+    if (props.loraAdapters) {
+      for (const adapter of props.loraAdapters) {
+        this.addLoraAdapter(adapter);
+      }
+    }
+    
+    // Prepare vllmArgs with LoRA modules if any
+    let vllmArgs = { ...props.compiledModel.vllmArgs };
+    
+    if (this.loraAdapters.length > 0) {
+      // Convert our LoRA adapters to the format expected by vllm
+      const loraModulesArray = this.loraAdapters.map(adapter => ({
+        name: adapter.name,
+        path: adapter.s3Uri,
+        base_model_name: adapter.baseModelName,
+      }));
+      
+      // Add or override the loraModules property in vllmArgs
+      vllmArgs = {
+        ...vllmArgs,
+        loraModules: loraModulesArray,
+      };
+    }
+    
+    // Get CLI args using the updated vllmArgs
+    const vllmCliArgs = VllmEngineArgumentsParser.cli(vllmArgs);
+    
     this.addContainerWithDefault("vLLM", {
       image: image.image,
       portMappings: [


### PR DESCRIPTION
# LoRA support for vllmNxdInference (simplified approach)

このPRでは vllmNxdInference 系のコンストラクトにLoRA対応を追加します。汎用アセットではなくLoRAに特化した実装にしています。

## 1. LoRAアダプター設定の追加
- LoraAdapterConfig インターフェースを追加し、ローカルファイルとS3オブジェクトの両方をサポート
- VllmNxdInferenceTaskDefinitionProps にLoRAアダプター設定を追加

## 2. VllmNxdInferenceTaskDefinition クラスの拡張
- LoRAに特化した addLoraAdapter() メソッドを実装
- ローカルアセットはCDKの標準機能 s3assets.Asset を使用
- S3アセットは適切な権限の付与と参照をサポート

## 使用例


## 改善点
- 汎用アセット管理のフレームワークではなく、CDKの標準機能を活用しシンプルな実装に
- LoRA固有の機能を vllmNxdInference 系のコンストラクトに限定し、基底クラスには影響なし
- アセットタイプの判別なしでシンプルな設計

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_