### PR TITLE
Add LoRA support with VllmLoraModule

### DIFF
--- a/src/base/lora/index.ts
+++ b/src/base/lora/index.ts
@@ -1,0 +1,140 @@
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3assets from "aws-cdk-lib/aws-s3-assets";
+import { Construct } from "constructs";
+
+/**
+ * Interface for LoRA adapter sources
+ */
+export interface ILoraAdapterSource {
+  /**
+   * Grant read access to this LoRA adapter source
+   * @param grantee The IAM principal to grant access to
+   */
+  grantRead(grantee: iam.IGrantable): iam.Grant;
+  
+  /**
+   * Get the S3 URI for this LoRA adapter source
+   * @returns S3 URI string
+   */
+  getS3Uri(): string;
+}
+
+/**
+ * LoRA adapter source from a local directory
+ */
+export class LocalLoraAdapterSource implements ILoraAdapterSource {
+  private readonly asset: s3assets.Asset;
+  
+  /**
+   * Create a LoRA adapter source from a local directory
+   * @param scope The construct scope
+   * @param id The construct ID
+   * @param path Path to the local LoRA adapter directory or file
+   * @param options Optional asset options
+   */
+  constructor(scope: Construct, id: string, path: string, options?: s3assets.AssetOptions) {
+    this.asset = new s3assets.Asset(scope, id, { path, ...options });
+  }
+  
+  public grantRead(grantee: iam.IGrantable): iam.Grant {
+    return this.asset.grantRead(grantee);
+  }
+  
+  public getS3Uri(): string {
+    return this.asset.s3ObjectUrl;
+  }
+}
+
+/**
+ * LoRA adapter source from an S3 bucket
+ */
+export class S3LoraAdapterSource implements ILoraAdapterSource {
+  /**
+   * Create a LoRA adapter source from an S3 object
+   * @param bucket The S3 bucket containing the LoRA adapter
+   * @param key The S3 key to the LoRA adapter
+   */
+  constructor(private readonly bucket: s3.IBucket, private readonly key: string) {}
+  
+  public grantRead(grantee: iam.IGrantable): iam.Grant {
+    return this.bucket.grantRead(grantee, this.key);
+  }
+  
+  public getS3Uri(): string {
+    return `s3://${this.bucket.bucketName}/${this.key}`;
+  }
+}
+
+/**
+ * Properties for VllmLoraModule
+ */
+export interface VllmLoraModuleProps {
+  /**
+   * Name of the LoRA adapter
+   * @default Construct ID
+   */
+  readonly loraName?: string;
+  
+  /**
+   * Source of the LoRA adapter
+   */
+  readonly source: ILoraAdapterSource;
+  
+  /**
+   * Base model name for this adapter
+   * @default undefined
+   */
+  readonly baseModelName?: string;
+}
+
+/**
+ * Represents a vLLM LoRA module
+ */
+export class VllmLoraModule extends Construct {
+  /**
+   * Name of the LoRA adapter
+   */
+  public readonly loraName: string;
+  
+  /**
+   * Source of the LoRA adapter
+   */
+  public readonly source: ILoraAdapterSource;
+  
+  /**
+   * Base model name (optional)
+   */
+  public readonly baseModelName?: string;
+  
+  /**
+   * Create a vLLM LoRA module
+   * @param scope The construct scope
+   * @param id The construct ID
+   * @param props The module properties
+   */
+  constructor(scope: Construct, id: string, props: VllmLoraModuleProps) {
+    super(scope, id);
+    this.loraName = props.loraName ?? id;
+    this.source = props.source;
+    this.baseModelName = props.baseModelName;
+  }
+  
+  /**
+   * Convert to JSON object in the format expected by vLLM
+   */
+  public toJSON(): { [key: string]: any } {
+    return {
+      name: this.loraName,
+      path: this.source.getS3Uri(),
+      base_model_name: this.baseModelName
+    };
+  }
+  
+  /**
+   * Convert to string representation
+   */
+  public toString(): string {
+    return JSON.stringify(this);
+  }
+}

--- a/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
+++ b/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
@@ -1,3 +1,5 @@
+import { VllmLoraModule } from "../../lora";
+
 /**
  * Log level options for Uvicorn
  */
@@ -355,9 +357,13 @@ export interface VllmNamedArguments {
 
   /**
    * LoRA module configurations.
+  /**
+   * LoRA module configurations.
    * @example {"name": "name", "path": "lora_path", "base_model_name": "id"}
+   * 
+   * Can be either a JSON object or an array of VllmLoraModule objects.
    */
-  readonly loraModules?: { [key: string]: any };
+  readonly loraModules?: { [key: string]: any } | VllmLoraModule[];
 
   /**
    * Prompt adapter configurations in the format name=path. Multiple adapters can be specified.
@@ -1278,7 +1284,7 @@ export abstract class VllmEngineArgumentsParser {
           return value ? [`--${key}`] : [];
         }
         if (Array.isArray(value)) {
-          return [`--${key}`, ...value.map((v) => `${v}`)];
+          return [`--${key}`, ...value.map(String)];
         }
         if (typeof value === "object") {
           return [`--${key}`, `'${JSON.stringify(value)}'`];

--- a/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
@@ -1,5 +1,7 @@
 import { Duration } from "aws-cdk-lib";
 import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3assets from "aws-cdk-lib/aws-s3-assets";
 import {
   ApplicationListener,
   ApplicationLoadBalancer,
@@ -13,6 +15,7 @@ import {
   NeuronxTaskDefinition,
   NeuronxTaskDefinitionPropsBase,
 } from "../base/aws-ecs-patterns";
+import { VllmLoraModule } from "../base/lora";
 import { INeuronxImage, PytorchTrainingNeuronxImage } from "../base/neuronx";
 import { INeuronxContainerImage } from "../base/neuronx-compiler";
 import { VllmEngineArgumentsParser } from "../base/server-engine/vllm-engine";
@@ -88,12 +91,33 @@ export interface VllmNxdInferenceTaskDefinitionProps
   readonly environment?: {
     [key: string]: string;
   };
+  
+  /**
+   * LoRA modules to be used with this task definition.
+   * @default - No LoRA modules
+   */
+  readonly loraModules?: VllmLoraModule[];
 }
 
 /**
  * Task definition for VllmNxdInference.
  */
 export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
+  private readonly loraModules: VllmLoraModule[] = [];
+
+  /**
+   * Add a LoRA module to this task definition.
+   * 
+   * @param module The LoRA module to add
+   * @returns This task definition for chaining
+   */
+  public addLoraModule(module: VllmLoraModule): VllmNxdInferenceTaskDefinition {
+    // Grant read access to the module's source
+    module.source.grantRead(this.taskRole);
+    
+    this.loraModules.push(module);
+    return this;
+  }
   constructor(
     scope: Construct,
     id: string,
@@ -112,9 +136,26 @@ export class VllmNxdInferenceTaskDefinition extends NeuronxTaskDefinition {
       props.image ??
       new VllmNxdInferenceImage(PytorchTrainingNeuronxImage.LATEST);
     const port = props.compiledModel.vllmArgs.port ?? 8000;
-    const vllmCliArgs = VllmEngineArgumentsParser.cli(
-      props.compiledModel.vllmArgs,
-    );
+    
+    // Add LoRA modules if specified in props
+    if (props.loraModules) {
+      for (const module of props.loraModules) {
+        this.addLoraModule(module);
+      }
+    }
+    
+    // Prepare vllmArgs with LoRA modules if any
+    let vllmArgs = { ...props.compiledModel.vllmArgs };
+    
+    if (this.loraModules.length > 0) {
+      // Add or override the loraModules property in vllmArgs
+      vllmArgs = {
+        ...vllmArgs,
+        loraModules: this.loraModules,
+      };
+    }
+    
+    const vllmCliArgs = VllmEngineArgumentsParser.cli(vllmArgs);
     this.addContainerWithDefault("vLLM", {
       image: image.image,
       portMappings: [


### PR DESCRIPTION
This PR adds LoRA support to vllmNxdInference constructs using the new VllmLoraModule design pattern.

## Features
- Added a  construct to represent LoRA adapters
- Support for sources from both local files and S3 buckets
- Type-safe API for adding LoRA modules to 
- Enhanced VllmEngineArgumentsParser to handle LoRA modules properly

## Usage
