### PR TITLE
fix: Compiler Lacks Read Permission for S3 Bucket When Model Source Is in S3

### DIFF
--- a/src/base/neuronx-compiler/neuronx-compiler.ts
+++ b/src/base/neuronx-compiler/neuronx-compiler.ts
@@ -187,6 +187,7 @@ export class NeuronxCompiler extends Construct {
         },
       ],
     });
+    props.model.bucket?.grantRead(computeEnvironment.instanceRole);
     props.bucket.grantReadWrite(computeEnvironment.instanceRole);
     this.jobDefinition = new NeuronxBatchEcsJobDefinition(
       this,


### PR DESCRIPTION
When the model source is stored in an S3 bucket, the compiler does not have the necessary read permissions for that bucket. As a result, the compilation process fails due to insufficient access rights. Please ensure that the compiler is granted appropriate read access to the relevant S3 bucket to resolve this issue

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
