### PR TITLE
fix: vLLM Server CLI Args to Accept Override Config Without Requiring Raw JSON

### DIFF
--- a/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
+++ b/src/base/server-engine/vllm-engine/vllm-engine-argments.ts
@@ -1284,7 +1284,7 @@ export abstract class VllmEngineArgumentsParser {
           return [`--${key}`, ...value.map((v) => `${v}`)];
         }
         if (typeof value === "object") {
-          return [`--${key}`, `'${JSON.stringify(value)}'`];
+          return [`--${key}`, JSON.stringify(value)];
         }
         return [`--${key}`, `${value}`];
       });


### PR DESCRIPTION
Previously, the vLLM server CLI required the override config to be provided as raw JSON. This PR modifies the behavior so that the override config can be passed without needing to supply raw JSON directly. This change improves usability and aligns the CLI argument handling with user expectations.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
