### PR TITLE
fix: remove cfn response from dependencies

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -130,10 +130,6 @@
       "type": "build"
     },
     {
-      "name": "cfn-response",
-      "type": "bundled"
-    },
-    {
       "name": "@aws-cdk/aws-sagemaker-alpha",
       "version": "2.200.1-alpha.0",
       "type": "peer"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -303,13 +303,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-cdk/integ-runner,@aws-cdk/integ-tests-alpha,@aws-sdk/client-batch,@aws-sdk/client-lambda,@types/aws-lambda,@types/cfn-response,@types/jest,@types/node,esbuild,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,jsii-diff,jsii-pacmak,prettier,projen,ts-jest,ts-node,typescript,cfn-response"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-cdk/integ-runner,@aws-cdk/integ-tests-alpha,@aws-sdk/client-batch,@aws-sdk/client-lambda,@types/aws-lambda,@types/cfn-response,@types/jest,@types/node,esbuild,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,jsii-diff,jsii-pacmak,prettier,projen,ts-jest,ts-node,typescript"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @aws-cdk/aws-sagemaker-alpha @aws-cdk/integ-runner @aws-cdk/integ-tests-alpha @aws-sdk/client-batch @aws-sdk/client-lambda @types/aws-lambda @types/cfn-response @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser commit-and-tag-version esbuild eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii prettier projen ts-jest ts-node typescript cfn-response aws-cdk-lib constructs"
+          "exec": "yarn upgrade @aws-cdk/aws-sagemaker-alpha @aws-cdk/integ-runner @aws-cdk/integ-tests-alpha @aws-sdk/client-batch @aws-sdk/client-lambda @types/aws-lambda @types/cfn-response @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser commit-and-tag-version esbuild eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii prettier projen ts-jest ts-node typescript aws-cdk-lib constructs"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -30,7 +30,6 @@ const project = new awscdk.AwsCdkConstructLibrary({
     "@aws-sdk/client-lambda",
     "esbuild",
   ],
-  bundledDeps: ["cfn-response"],
   peerDeps: [`@aws-cdk/aws-sagemaker-alpha@${cdkVersion}-alpha.0`],
   gitignore: ["src/**/index.js"],
   githubOptions: {

--- a/package.json
+++ b/package.json
@@ -75,12 +75,8 @@
     "constructs": "^10.0.5"
   },
   "dependencies": {
-    "@aws-cdk/aws-sagemaker-alpha": "2.200.1-alpha.0",
-    "cfn-response": "^1.0.1"
+    "@aws-cdk/aws-sagemaker-alpha": "2.200.1-alpha.0"
   },
-  "bundledDependencies": [
-    "cfn-response"
-  ],
   "keywords": [
     "cdk",
     "neuronx"

--- a/src/base/neuronx-compiler/private/await-compile-job/cfn-response.ts
+++ b/src/base/neuronx-compiler/private/await-compile-job/cfn-response.ts
@@ -1,0 +1,40 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { CloudFormationCustomResourceEvent } from "aws-lambda";
+
+export const cfnRespond = async (
+  event: CloudFormationCustomResourceEvent,
+  context: any,
+  responseStatus: "SUCCESS" | "FAILED",
+  responseData: any,
+  physicalResourceId?: string,
+  noEcho?: boolean,
+) => {
+  const body = JSON.stringify({
+    Status: responseStatus,
+    Reason:
+      "See the details in CloudWatch Log Stream: " + context.logStreamName,
+    PhysicalResourceId: physicalResourceId || context.logStreamName,
+    StackId: event.StackId,
+    RequestId: event.RequestId,
+    LogicalResourceId: event.LogicalResourceId,
+    NoEcho: noEcho || false,
+    Data: responseData,
+  });
+
+  try {
+    await fetch(event.ResponseURL, {
+      method: "PUT",
+      headers: {
+        "content-type": "",
+      },
+      body,
+    });
+    console.log("Response body:\n", body);
+  } catch (error) {
+    console.log(
+      `HTTP request error, ${(error as Error).message
+        .replace(/X-Amz-Credential=[^&\s]+/i, "X-Amz-Credential=*****")
+        .replace(/X-Amz-Signature=[^&\s]+/i, "X-Amz-Signature=*****")}`,
+    );
+  }
+};

--- a/src/base/neuronx-compiler/private/await-compile-job/index.ts
+++ b/src/base/neuronx-compiler/private/await-compile-job/index.ts
@@ -13,7 +13,7 @@ import {
   type CdkCustomResourceHandler,
   type CdkCustomResourceIsCompleteHandler,
 } from "aws-lambda";
-import * as cfnresponse from "cfn-response";
+import { cfnRespond } from "./cfn-response";
 
 const region = process.env.AWS_DEFAULT_REGION ?? "us-east-1";
 const batch = new BatchClient({
@@ -94,7 +94,7 @@ const isJobComplete = async (event: CdkCustomResourceIsCompleteEvent) => {
 };
 
 export const isComplete: CdkCustomResourceIsCompleteHandler = async (event) => {
-  const respond = async (body: WaitConditionRequestBody) =>
+  const waitConditionRespond = async (body: WaitConditionRequestBody) =>
     fetch(event.waitConditionCallbackURL, {
       method: "PUT",
       headers: {
@@ -110,7 +110,7 @@ export const isComplete: CdkCustomResourceIsCompleteHandler = async (event) => {
         IsComplete: false,
       };
     }
-    const response = await respond({
+    const response = await waitConditionRespond({
       Status: "SUCCESS",
       Reason: "Compile Success",
       UniqueId: event.jobId,
@@ -119,7 +119,7 @@ export const isComplete: CdkCustomResourceIsCompleteHandler = async (event) => {
     console.log("response", await response.text());
     return result;
   } catch (error) {
-    const response = await respond({
+    const response = await waitConditionRespond({
       Status: "FAILURE",
       Reason: (error as Error).message,
       UniqueId: event.jobId,
@@ -146,51 +146,23 @@ export const entrypoint: CloudFormationCustomResourceHandler = async (
         }),
       }),
     );
-    const response = {
-      PhysicalResourceId: event.LogicalResourceId
-        ? event.LogicalResourceId
-        : undefined,
-      Data: {},
-      Status: cfnresponse.SUCCESS,
-    };
-    await sendResponse(event, context, response);
-  } catch (error) {
-    console.log(error);
-    const response = {
-      PhysicalResourceId: event.LogicalResourceId
-        ? event.LogicalResourceId
-        : undefined,
-      Data: {},
-      Status: cfnresponse.FAILED,
-    };
-    await sendResponse(event, context, response);
-  }
-};
-
-/**
- * Send response back to cloudformation
- * @param event
- * @param context
- * @param response
- */
-async function sendResponse(
-  event: any,
-  context: any,
-  response: {
-    Status: "SUCCESS" | "FAILED";
-    Data: any;
-    PhysicalResourceId?: string;
-  },
-) {
-  await new Promise(() =>
-    cfnresponse.send(
+    await cfnRespond(
       event,
       context,
-      response.Status,
-      response.Data,
-      response.PhysicalResourceId,
+      "SUCCESS",
+      {},
+      event.LogicalResourceId,
       false,
-    ),
-  );
-  return;
-}
+    );
+  } catch (error) {
+    console.log(error);
+    await cfnRespond(
+      event,
+      context,
+      "FAILED",
+      {},
+      event.LogicalResourceId,
+      false,
+    );
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2905,11 +2905,6 @@ case@1.6.3, case@^1.6.3:
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
-cfn-response@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cfn-response/-/cfn-response-1.0.1.tgz#a8ec03950c0683c51495e8ca680d9dc0b884b137"
-  integrity sha512-mHfgHUcGpIbmioV/gQ//5V+b8em/ZKFwAgzmbycflJ1q0AU66wlhIgarkYc4JXGgIca+0lxg+XEKO4ZwyZedaw==
-
 chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"


### PR DESCRIPTION
When deploy stack using this library, stack is rollback with 'Can not find cfn-response module' error. There are root cause at projen, but I think to remove dependency is better so I create this PR.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
