### PR TITLE
Add support for official AWS Neuron vLLM image

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,29 @@ pnpm i aws-cdk-neuronx-patterns
 > [!WARNING]
 > This construct uses an Inferentia2 instance on ECS. You may need to increase your request limit for your AWS account.
 
-By using the `VllmNxdInferenceCompiler` construct included in this construct library, models published on HuggingFace can be easily deployed to ECS with Application Load Balancer. To define using the `VllmNxdInferenceCompiler` construct:
+By using the `VllmNxdInferenceCompiler` construct included in this construct library, models published on HuggingFace can be easily deployed to ECS with Application Load Balancer. 
+
+### Using Official AWS Neuron vLLM Images
+
+This library supports the official AWS Neuron Deep Learning Containers for vLLM inference. You can use the `VllmInferenceNeuronxImage` class to reference these images and `VllmNxdInferenceImage.fromImage` to create a compatible image object:
+
+```typescript
+// Use the official vLLM Neuron Image
+const vllmImage = VllmNxdInferenceImage.fromImage(
+  VllmInferenceNeuronxImage.LATEST
+);
+
+// Use with task definition
+const taskDefinition = new VllmNxdInferenceTaskDefinition(this, 'TaskDefinition', {
+  vpc,
+  compiledModel,
+  image: vllmImage,
+});
+```
+
+### Basic Usage
+
+To define using the `VllmNxdInferenceCompiler` construct:
 
 ```ts
 import * as ec2 from "aws-cdk-lib/aws-ec2";

--- a/src/base/neuronx/deep-learning-containers.ts
+++ b/src/base/neuronx/deep-learning-containers.ts
@@ -7,6 +7,13 @@ export interface INeuronxImage {
 }
 abstract class NeuronxImage {
   static readonly size = Size.gibibytes(30);
+  /** Neuron SDK 2.24.0 */
+  static readonly SDK_2_24_0 = NeuronxImage.fromSdkVersion(
+    "2.24.0",
+    "3.10",
+    "2.7.0",
+    "22.04",
+  );
   /** Neuron SDK 2.23.0 */
   static readonly SDK_2_23_0 = NeuronxImage.fromSdkVersion(
     "2.23.0",
@@ -114,4 +121,51 @@ abstract class NeuronxImage {
 
 export class PytorchTrainingNeuronxImage extends NeuronxImage {
   static readonly imageName = "public.ecr.aws/neuron/pytorch-training-neuronx";
+}
+
+export class VllmInferenceNeuronxImage {
+  /**
+   * Neuron SDK 2.24.0 with vLLM 0.7.2
+   * Supported on trn1, trn2, inf2
+   */
+  static readonly SDK_2_24_0 = VllmInferenceNeuronxImage.fromSdkVersion(
+    "2.24.0",
+    "0.7.2",
+    "3.10",
+    "22.04",
+  );
+  
+  /** Latest Neuron SDK */
+  static readonly LATEST = VllmInferenceNeuronxImage.SDK_2_24_0;
+  
+  readonly imageName: string;
+  readonly imageTag: string;
+  readonly sdkVersion: string;
+  readonly vllmVersion: string;
+  
+  private constructor(props: {
+    readonly imageName: string;
+    readonly imageTag: string;
+    readonly sdkVersion: string;
+    readonly vllmVersion: string;
+  }) {
+    this.imageName = props.imageName;
+    this.imageTag = props.imageTag;
+    this.sdkVersion = props.sdkVersion;
+    this.vllmVersion = props.vllmVersion;
+  }
+  
+  static fromSdkVersion(
+    sdkVersion: string,
+    vllmVersion: string,
+    pythonVersion: string,
+    ubuntuVersion: string,
+  ): VllmInferenceNeuronxImage {
+    return new VllmInferenceNeuronxImage({
+      sdkVersion,
+      vllmVersion,
+      imageName: "public.ecr.aws/neuron/pytorch-inference-vllm-neuronx",
+      imageTag: `${vllmVersion}-neuronx-py${pythonVersion.replace(".", "")}-sdk${sdkVersion}-ubuntu${ubuntuVersion}`,
+    });
+  }
 }

--- a/src/base/neuronx/index.ts
+++ b/src/base/neuronx/index.ts
@@ -3,3 +3,4 @@ export * from "./deep-learning-containers";
 export * from "./model";
 export * from "./neuron-optimized-machine-image";
 export * from "./neuronx-instance-type";
+export * from "./vllm-inference";

--- a/src/base/neuronx/vllm-inference.ts
+++ b/src/base/neuronx/vllm-inference.ts
@@ -1,0 +1,72 @@
+import { INeuronxImage } from './deep-learning-containers';
+
+/**
+ * vLLM Inference Images for Neuron from AWS Neuron Deep Learning Containers.
+ * @see https://github.com/aws-neuron/deep-learning-containers
+ */
+export class VllmInferenceNeuronxImage implements INeuronxImage {
+  /**
+   * Latest Neuron SDK 2.24.0 with vLLM 0.7.2
+   * Supported on trn1, trn2, inf2
+   */
+  static readonly SDK_2_24_0 = VllmInferenceNeuronxImage.fromSdkVersion(
+    '2.24.0',
+    '0.7.2',
+    '3.10',
+    '22.04',
+  );
+
+  /**
+   * Latest version of the vLLM Inference Image
+   */
+  static readonly LATEST = VllmInferenceNeuronxImage.SDK_2_24_0;
+
+  /**
+   * The name of the ECR image.
+   */
+  readonly imageName: string;
+
+  /**
+   * The tag of the ECR image.
+   */
+  readonly imageTag: string;
+
+  /**
+   * The SDK version.
+   */
+  readonly sdkVersion: string;
+
+  /**
+   * The vLLM version.
+   */
+  readonly vllmVersion: string;
+
+  constructor(props: {
+    readonly imageName: string;
+    readonly imageTag: string;
+    readonly sdkVersion: string;
+    readonly vllmVersion: string;
+  }) {
+    this.imageName = props.imageName;
+    this.imageTag = props.imageTag;
+    this.sdkVersion = props.sdkVersion;
+    this.vllmVersion = props.vllmVersion;
+  }
+
+  /**
+   * Create a vLLM inference image from SDK version.
+   */
+  static fromSdkVersion(
+    sdkVersion: string,
+    vllmVersion: string,
+    pythonVersion: string,
+    ubuntuVersion: string,
+  ): VllmInferenceNeuronxImage {
+    return new VllmInferenceNeuronxImage({
+      sdkVersion,
+      vllmVersion,
+      imageName: 'public.ecr.aws/neuron/pytorch-inference-vllm-neuronx',
+      imageTag: `${vllmVersion}-neuronx-py${pythonVersion.replace('.', '')}-sdk${sdkVersion}-ubuntu${ubuntuVersion}`,
+    });
+  }
+}

--- a/src/examples/vllm-nxd-inference/using-official-image.ts
+++ b/src/examples/vllm-nxd-inference/using-official-image.ts
@@ -1,0 +1,54 @@
+import { Stack, StackProps } from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+import {
+  ApplicationLoadBalancedVllmNxDInferenceService,
+  Model,
+  VllmNxdInferenceCompiler,
+  VllmNxdInferenceImage,
+  VllmNxdInferenceTaskDefinition,
+  VllmInferenceNeuronxImage
+} from '../../..';
+
+export class UsingOfficialImageExample extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    // Create a VPC and S3 bucket for compiled model artifacts
+    const vpc = new ec2.Vpc(this, 'Vpc', { maxAzs: 2 });
+    const bucket = new s3.Bucket(this, 'Bucket');
+
+    // Choose the Hugging Face model to deploy
+    const model = Model.fromHuggingFace('meta-llama/Llama-2-7b-chat-hf');
+
+    // Compile the model for inference
+    const compiler = new VllmNxdInferenceCompiler(this, 'Compiler', {
+      vpc,
+      bucket,
+      model,
+    });
+    const compiledModel = compiler.compile();
+
+    // Use the official vLLM Neuron Image
+    const vllmImage = VllmNxdInferenceImage.fromImage(
+      VllmInferenceNeuronxImage.LATEST
+    );
+
+    // Create task definition with the official image
+    const taskDefinition = new VllmNxdInferenceTaskDefinition(
+      this,
+      'TaskDefinition',
+      {
+        vpc,
+        compiledModel,
+        image: vllmImage,
+      }
+    );
+
+    // Deploy the service with ALB
+    new ApplicationLoadBalancedVllmNxDInferenceService(this, 'Service', {
+      taskDefinition,
+    });
+  }
+}

--- a/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
+++ b/src/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.ts
@@ -13,7 +13,11 @@ import {
   NeuronxTaskDefinition,
   NeuronxTaskDefinitionPropsBase,
 } from "../base/aws-ecs-patterns";
-import { INeuronxImage, PytorchTrainingNeuronxImage } from "../base/neuronx";
+import { 
+  INeuronxImage, 
+  PytorchTrainingNeuronxImage,
+  VllmInferenceNeuronxImage 
+} from "../base/neuronx";
 import { INeuronxContainerImage } from "../base/neuronx-compiler";
 import { VllmEngineArgumentsParser } from "../base/server-engine/vllm-engine";
 import { VllmNxdInferenceCompiledModel } from "./vllm-nxd-inference-compiler";
@@ -58,10 +62,25 @@ export abstract class VllmNxdInferenceImageBase
 
 /**
  * Inference container image for vLLM on NxD Inference.
+ * This image builds a custom container that installs vLLM from source.
+ * 
+ * Consider using {@link VllmNxdInferenceImage.fromImage} with {@link PytorchInferenceVllmNeuronxImage}
+ * to use the official AWS Neuron Deep Learning Containers which come with vLLM pre-installed.
+ * 
  * @example new VllmNxdInferenceImage(PytorchTrainingNeuronxImage.LATEST)
  */
 export class VllmNxdInferenceImage extends VllmNxdInferenceImageBase {
   readonly image: ecs.ContainerImage;
+
+  /**
+   * Create a VllmNxdInferenceImage from a custom neuronx image.
+   * This will build a container image using a Dockerfile that installs vLLM from source.
+   * 
+   * @example
+   * ```ts
+   * new VllmNxdInferenceImage(PytorchTrainingNeuronxImage.LATEST)
+   * ```
+   */
   constructor(
     neruonxImage: INeuronxImage,
     options?: VllmNxdInferenceImageOptions,
@@ -79,6 +98,28 @@ export class VllmNxdInferenceImage extends VllmNxdInferenceImageBase {
       },
     );
   }
+  
+  /**
+   * Create a VllmNxdInferenceImage from an existing neuronx image.
+   * This is useful for using the official AWS Neuron Deep Learning Containers.
+   * 
+   * @example
+   * ```ts
+   * VllmNxdInferenceImage.fromImage(PytorchInferenceVllmNeuronxImage.LATEST)
+   * ```
+   */
+  static fromImage(neuronxImage: INeuronxImage): VllmNxdInferenceImage {
+    class FromImageVllmNxdInferenceImage extends VllmNxdInferenceImage {
+      constructor() {
+        super(neuronxImage);
+        this.image = ecs.ContainerImage.fromRegistry(
+          `${neuronxImage.imageName}:${neuronxImage.imageTag}`
+        );
+      }
+    }
+    
+    return new FromImageVllmNxdInferenceImage();
+  }
 }
 
 /**
@@ -94,7 +135,7 @@ export interface VllmNxdInferenceTaskDefinitionProps
    * The image to be used for the container.
    * @default - latest VllmNxdInferenceImage
    */
-  readonly image?: VllmNxdInferenceImage;
+  readonly image?: VllmNxdInferenceImageBase;
   /**
    * The environment variables to pass to the container.
    * This is only applicable when using container runtime.

--- a/test/vllm-nxd-inference/vllm-inference-neuronx-image.test.ts
+++ b/test/vllm-nxd-inference/vllm-inference-neuronx-image.test.ts
@@ -1,0 +1,44 @@
+import { VllmInferenceNeuronxImage } from '../../src/base/neuronx';
+
+describe('VllmInferenceNeuronxImage', () => {
+  test('LATEST points to the latest SDK version', () => {
+    expect(VllmInferenceNeuronxImage.LATEST).toBe(VllmInferenceNeuronxImage.SDK_2_24_0);
+  });
+
+  test('fromSdkVersion creates correct image reference', () => {
+    const image = VllmInferenceNeuronxImage.fromSdkVersion(
+      '2.24.0',
+      '0.7.2',
+      '3.10',
+      '22.04',
+    );
+
+    expect(image.imageName).toBe('public.ecr.aws/neuron/pytorch-inference-vllm-neuronx');
+    expect(image.imageTag).toBe('0.7.2-neuronx-py310-sdk2.24.0-ubuntu22.04');
+    expect(image.sdkVersion).toBe('2.24.0');
+    expect(image.vllmVersion).toBe('0.7.2');
+  });
+
+  test('constructor sets properties correctly', () => {
+    const image = new VllmInferenceNeuronxImage({
+      imageName: 'test-image',
+      imageTag: 'test-tag',
+      sdkVersion: '1.0.0',
+      vllmVersion: '0.8.0',
+    });
+
+    expect(image.imageName).toBe('test-image');
+    expect(image.imageTag).toBe('test-tag');
+    expect(image.sdkVersion).toBe('1.0.0');
+    expect(image.vllmVersion).toBe('0.8.0');
+  });
+
+  test('SDK_2_24_0 has correct properties', () => {
+    const image = VllmInferenceNeuronxImage.SDK_2_24_0;
+
+    expect(image.imageName).toBe('public.ecr.aws/neuron/pytorch-inference-vllm-neuronx');
+    expect(image.imageTag).toBe('0.7.2-neuronx-py310-sdk2.24.0-ubuntu22.04');
+    expect(image.sdkVersion).toBe('2.24.0');
+    expect(image.vllmVersion).toBe('0.7.2');
+  });
+});

--- a/test/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.test.ts
+++ b/test/vllm-nxd-inference/vllm-nxd-inference-ecs-patterns.test.ts
@@ -1,0 +1,19 @@
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import { VllmInferenceNeuronxImage } from '../../src/base/neuronx';
+import { VllmNxdInferenceImage } from '../../src/vllm-nxd-inference';
+
+describe('VllmNxdInferenceImage', () => {
+  test('fromImage creates an image with registry reference', () => {
+    const neuronxImage = VllmInferenceNeuronxImage.LATEST;
+    
+    const vllmImage = VllmNxdInferenceImage.fromImage(neuronxImage);
+    
+    expect(vllmImage.sdkVersion).toBe(neuronxImage.sdkVersion);
+    expect(vllmImage.vllmGitBranch).toBe('main');
+    expect(vllmImage.vllmGitCommitHash).toBe('');
+    
+    // We cannot easily test the image property since it's a ContainerImage,
+    // but we can verify it's an instance of ContainerImage
+    expect(vllmImage.image).toBeInstanceOf(ecs.ContainerImage);
+  });
+});


### PR DESCRIPTION
## Description

This PR adds support for the official AWS Neuron vLLM inference container images that were recently made available in the [aws-neuron/deep-learning-containers](https://github.com/aws-neuron/deep-learning-containers) repository.

### Changes

1. Added a new `VllmInferenceNeuronxImage` class to access the official vLLM inference images
2. Extended the existing `VllmNxdInferenceImage` with a static `fromImage()` method that allows using the official images seamlessly
3. Updated the README with usage instructions
4. Added example code and tests

### Benefits

- Users can now easily use the officially supported AWS Neuron vLLM images
- No need to build custom containers for vLLM inference
- Latest vLLM version with AWS Neuron optimizations is readily available

### How to use

```typescript
// Use the official vLLM Neuron Image
const vllmImage = VllmNxdInferenceImage.fromImage(
  VllmInferenceNeuronxImage.LATEST
);

// Use with task definition
const taskDefinition = new VllmNxdInferenceTaskDefinition(this, 'TaskDefinition', {
  vpc,
  compiledModel,
  image: vllmImage,
});
```

This approach maintains backward compatibility with existing code while adding support for the new official images.

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1751100535807439 -->